### PR TITLE
Add live reload

### DIFF
--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -1,4 +1,7 @@
-.PHONY: dev
+.PHONY: build-dependencies dev
+
+build-dependencies:
+	go get github.com/cosmtrek/air@v1.15.1
 
 dev:
 	go run cmd/api/main.go

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -1,7 +1,8 @@
-.PHONY: build-dependencies dev
-
-build-dependencies:
-	go get github.com/cosmtrek/air@v1.15.1
+.PHONY: dev install-dependencies
 
 dev:
 	air -c cmd/api/.air.toml
+
+install-dependencies:
+	go get github.com/cosmtrek/air@v1.15.1
+	go mod tidy

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -4,4 +4,4 @@ build-dependencies:
 	go get github.com/cosmtrek/air@v1.15.1
 
 dev:
-	go run cmd/api/main.go
+	air -c cmd/api/.air.toml

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -13,7 +13,8 @@
 ### Development
 
 #### Build dependencies
-This project using [`air`](https://github.com/cosmtrek/air) for live reloading. It need to be built as a binary file in `$GOPATH`.
+[`air`](https://github.com/cosmtrek/air) is used for live reloading. It needs to be built as a binary file in `$GOPATH`.
+
 
 ```sh
 make build-dependencies
@@ -25,7 +26,7 @@ make build-dependencies
 make dev
 ```
 
-To visit app locally: `localhost:8080`
+The application runs locally at http://localhost:8080
 
 ### Test
 

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -14,14 +14,17 @@
 
 #### Build dependencies
 This project using [`air`](https://github.com/cosmtrek/air) for live reloading. It need to be built as a binary file in `$GOPATH`.
+
 ```sh
 make build-dependencies
 ```
 
 #### Start development server
+
 ```sh
 make dev
 ```
+
 To visit app locally: `localhost:8080`
 
 ### Test

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -17,7 +17,7 @@
 
 
 ```sh
-make build-dependencies
+make install-dependencies
 ```
 
 #### Start development server

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -13,7 +13,7 @@
 ### Development
 
 #### Build dependencies
-This project using [`air`](https://github.com/cosmtrek/air) for live reloading.
+This project using [`air`](https://github.com/cosmtrek/air) for live reloading. It need to be built as a binary file in `$GOPATH`.
 ```sh
 make build-dependencies
 ```

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -12,11 +12,17 @@
 
 ### Development
 
-- Start development server
+#### Build dependencies
+This project using [`air`](https://github.com/cosmtrek/air) for live reloading.
+```sh
+make build-dependencies
+```
 
+#### Start development server
 ```sh
 make dev
 ```
+To visit app locally: `localhost:8080`
 
 ### Test
 

--- a/{{cookiecutter.app_name}}/cmd/api/.air.toml
+++ b/{{cookiecutter.app_name}}/cmd/api/.air.toml
@@ -1,0 +1,49 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root = "."
+tmp_dir = "tmp"
+
+[build]
+# Just plain old shell command. You could use `make` as well.
+cmd = "go build -o ./cmd/api/tmp/main ./cmd/api/main.go"
+# Binary file yields from `cmd`.
+bin = "cmd/api/tmp/main"
+# Customize binary.
+full_bin = "APP_ENV=dev APP_USER=air ./cmd/api/tmp/main"
+# Watch these filename extensions.
+include_ext = ["go", "tpl", "tmpl", "html"]
+# Ignore these filename extensions or directories.
+exclude_dir = ["assets", "tmp", "vendor", "node_modules"]
+# Watch these directories if you specified.
+include_dir = []
+# Exclude files.
+exclude_file = []
+# Exclude unchanged files.
+exclude_unchanged = true
+# This log file places in your tmp_dir.
+log = "air.log"
+# It's not necessary to trigger build each time file changes if it's too frequent.
+delay = 1000 # ms
+# Stop running old binary when build errors occur.
+stop_on_error = true
+# Send Interrupt signal before killing process (windows does not support this feature)
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 500 # ms
+
+[log]
+# Show log time
+time = false
+
+[color]
+# Customize each part's color. If no color found, use the raw app log.
+main = "magenta"
+watcher = "cyan"
+build = "yellow"
+runner = "green"
+
+[misc]
+# Delete tmp directory on exit
+clean_on_exit = true

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -2,4 +2,7 @@ module github.com/nimblehq/{{cookiecutter.app_name}}
 
 go 1.15
 
-require github.com/gin-gonic/gin v1.6.3
+require (
+	github.com/cosmtrek/air v1.15.1 // indirect
+	github.com/gin-gonic/gin v1.6.3
+)


### PR DESCRIPTION
## What happened 👀
Resolve #16 
- Add live reload ([air](https://github.com/cosmtrek/air))
- Add `make build-dependencies` command as `air` need to be built as a binary file.
- Update `dev` command to start server using `air`
 
## Insight 📝
I choose `air` because their config is flexible and easy to configure with our project structure.

**Testing step**
- Generate project
  - Install cookiecutter (you can follow the instruction in README).
  - Checkout to this branch.
  - Run command cookiecutter <path to this repo in your local machine>
  - Your new application is created 🎉 .
- Run development server
  - Follow the `README` in your created application to start development server.
  - Try to edit any `.go` file and save
 
## Proof Of Work 📹
Application must reload itself when save.
![5SmOBmtD7d](https://user-images.githubusercontent.com/29707647/107618954-f5305380-6c84-11eb-91db-f7179cf5115a.gif)
