### PR TITLE
Fix: Cookiecutter is not available using apt-get on Ubuntu 20.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,13 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
 
       - name: Install cookiecutter
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y cookiecutter
+        run: sudo -H python3 -m pip install cookiecutter
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Install cookiecutter
-        run: sudo apt-get install cookiecutter
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y cookiecutter
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3


### PR DESCRIPTION
https://github.com/nimblehq/gin-templates/issues/45

## What happened 👀

Install cookiecutter using `pip` instead of `apt-get`
 
## Insight 📝
N/A
 
## Proof Of Work 📹
CI is passed
![Screen Shot 2564-04-29 at 16 39 19](https://user-images.githubusercontent.com/29707647/116531514-75239c80-a909-11eb-8f58-e06339867ec2.png)