### PR TITLE
#50 Add variables rewrite and multiple option menu for variant and cs…

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,10 +2,7 @@
   "app_name": "default-app-name",
   "use_logrus": ["yes", "no"],
   "variant": ["API only", "Web only", "Both"],
-  "css_addon": ["None", "Bootstrap", "Tailwinds"],
 
   "_api_variant": "no",
-  "_web_variant": "no",
-  "_bootstrap_addon": "no",
-  "_tailwinds_addon": "no"
+  "_web_variant": "no"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,6 @@
 {
   "app_name": "default-app-name",
   "use_logrus": ["yes", "no"],
-  "web_variant": ["yes", "no"]
+  "variant": ["API only", "Web only", "Both"],
+  "css_addon": ["None", "Bootstrap", "Tailwinds"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,10 @@
   "app_name": "default-app-name",
   "use_logrus": ["yes", "no"],
   "variant": ["API only", "Web only", "Both"],
-  "css_addon": ["None", "Bootstrap", "Tailwinds"]
+  "css_addon": ["None", "Bootstrap", "Tailwinds"],
+
+  "_api_variant": "n",
+  "_web_variant": "n",
+  "_bootstrap_addon": "n",
+  "_tailwinds_addon": "n"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,8 +4,8 @@
   "variant": ["API only", "Web only", "Both"],
   "css_addon": ["None", "Bootstrap", "Tailwinds"],
 
-  "_api_variant": "n",
-  "_web_variant": "n",
-  "_bootstrap_addon": "n",
-  "_tailwinds_addon": "n"
+  "_api_variant": "no",
+  "_web_variant": "no",
+  "_bootstrap_addon": "no",
+  "_tailwinds_addon": "no"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -4,14 +4,19 @@ import shutil
 # Get the root project directory
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
 
-# Removes log helper folder
-def remove_logrus_files():
+def remove_files(path):
+    """
+    Removes files in path
+    """
     shutil.rmtree(os.path.join(
-        PROJECT_DIRECTORY, "helpers/log"
+        PROJECT_DIRECTORY, path
     ))
 
 # Print log with color
 def print_log(message):
+    """
+    Print log with color
+    """
     CYELLOW = '\33[33m'  # YELLOW color
     CEND = '\033[0m'  # END color
     print(CYELLOW + message + CEND)
@@ -20,7 +25,7 @@ def print_log(message):
 # Remove logrus add-on if not seleted
 if '{{ cookiecutter.use_logrus }}'.lower() == 'no':
     print_log('Removing logrus add-on')
-    remove_logrus_files()
+    remove_files("helpers/log")
 
 # Download the missing dependencies
 print_log('Downloading dependencies')
@@ -29,3 +34,9 @@ os.system("go mod tidy")
 # Format code
 print_log('Formating code')
 os.system("go fmt ./...")
+
+# # Use this snippet to remove files/folders based on
+# # cookiecutter.variables (cf pre_gen_project.py hook)
+# if '{{ cookiecutter.web_variant }}' == 'n':
+#     print_log('Removing web variant related files')
+#     remove_files('/path/to/remove')

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -37,6 +37,6 @@ os.system("go fmt ./...")
 
 # # Use this snippet to remove files/folders based on
 # # cookiecutter.variables (cf pre_gen_project.py hook)
-# if '{{ cookiecutter._web_variant }}' == 'n':
+# if '{{ cookiecutter._web_variant }}' == 'no':
 #     print_log('Removing web variant related files')
 #     remove_files('/path/to/remove')

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -37,6 +37,6 @@ os.system("go fmt ./...")
 
 # # Use this snippet to remove files/folders based on
 # # cookiecutter.variables (cf pre_gen_project.py hook)
-# if '{{ cookiecutter.web_variant }}' == 'n':
+# if '{{ cookiecutter._web_variant }}' == 'n':
 #     print_log('Removing web variant related files')
 #     remove_files('/path/to/remove')

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -14,19 +14,3 @@ API Variant
 {% if cookiecutter.variant in ['API only', 'Both'] %}
     {{ cookiecutter.update({ '_api_variant': 'yes' }) }}
 {% endif %}
-
------------
-CSS Addons
-cookiecutter._bootstrap_addon
-cookiecutter._tailwinds_addon
------------
-
-Only project with web:
-{% if cookiecutter._web_variant == 'yes' %}
-    {% if cookiecutter.css_addon == 'Bootstrap' %}
-        {{ cookiecutter.update({ '_bootstrap_addon': 'yes' }) }}
-    {% elif cookiecutter.css_addon == 'Tailwinds' %}
-        {{ cookiecutter.update({ '_tailwinds_addon': 'yes' }) }}
-    {% endif %}
-{% endif %}
-'''

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -5,17 +5,17 @@ Setting easy to read/maintain cookiecutter variables:
 Web Variant
 cookiecutter.web_addon
 -----------
-{% if cookiecutter.variant in ['Web only', 'Both'] %}
-    {{ cookiecutter.update({ "web_variant": "y" }) }}
+{% if cookiecutter.variant in ["Web only", "Both"] %}
+    {{ cookiecutter.update({ "web_variant": True }) }}
 {% else %}
-    {{ cookiecutter.update({ "web_variant": "n" }) }}
+    {{ cookiecutter.update({ "web_variant": False }) }}
 {% endif %}
 
 API Variant
-{% if cookiecutter.variant in ['API only', 'Both'] %}
-    {{ cookiecutter.update({ "api_variant": "y" }) }}
+{% if cookiecutter.variant in ["API only", "Both"] %}
+    {{ cookiecutter.update({ "api_variant": True }) }}
 {% else %}
-    {{ cookiecutter.update({ "api_variant": "n" }) }}
+    {{ cookiecutter.update({ "api_variant": False }) }}
 {% endif %}
 
 -----------
@@ -23,15 +23,15 @@ CSS Addon
 cookiecutter.css_addon
 -----------
 Ignored unless a condition matches
-{{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
-{{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
+{{ cookiecutter.update({ "bootstrap_addon": False }) }}
+{{ cookiecutter.update({ "tailwinds_addon": False }) }}
 
 Only project with web:
-{% if cookiecutter.web_variant == 'y' %}
-    {% if cookiecutter.css_addon == 'Bootstrap' %}
-        {{ cookiecutter.update({ "bootstrap_addon": "y" }) }}
-    {% elif cookiecutter.css_addon == 'Tailwinds' %}
-        {{ cookiecutter.update({ "tailwinds_addon": "y" }) }}
+{% if cookiecutter.web_variant %}
+    {% if cookiecutter.css_addon == "Bootstrap" %}
+        {{ cookiecutter.update({ "bootstrap_addon": True }) }}
+    {% elif cookiecutter.css_addon == "Tailwinds" %}
+        {{ cookiecutter.update({ "tailwinds_addon": True }) }}
     {% endif %}
 {% endif %}
 """

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,42 @@
+"""
+Setting easy to read/maintain variables:
+
+-----------
+Web Variant
+-----------
+{% if cookiecutter.variant in ['Web only', 'Both'] %}
+    {{ cookiecutter.update({ "web_variant": "y" }) }}
+{% else %}
+    {{ cookiecutter.update({ "web_variant": "n" }) }}
+{% endif %}
+
+API Variant
+{% if cookiecutter.variant in ['API only', 'Both'] %}
+    {{ cookiecutter.update({ "api_variant": "y" }) }}
+{% else %}
+    {{ cookiecutter.update({ "api_variant": "n" }) }}
+{% endif %}
+
+-----------
+CSS Addon
+-----------
+Only project with web:
+{% if cookiecutter.web_variant == 'y' %}
+    {% if cookiecutter.css_addon == 'Bootstrap' %}
+        {{ cookiecutter.update({ "bootstrap_addon": "y" }) }}
+        {{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
+    {% else %}
+        {% if cookiecutter.css_addon == 'Tailwinds' %}
+            {{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
+            {{ cookiecutter.update({ "tailwinds_addon": "y" }) }}
+        {% else %}
+            {{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
+            {{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
+        {% endif %}
+    {% endif %}
+Ignored for API only projects
+{% else %}
+    {{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
+    {{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
+{% endif %}
+"""

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,21 +1,21 @@
-"""
+'''
 Setting easy to read/maintain cookiecutter variables:
 
 -----------
 Web Variant
 cookiecutter.web_addon
 -----------
-{% if cookiecutter.variant in ["Web only", "Both"] %}
-    {{ cookiecutter.update({ "web_variant": True }) }}
+{% if cookiecutter.variant in ['Web only', 'Both'] %}
+    {{ cookiecutter.update({ 'web_variant': 'y' }) }}
 {% else %}
-    {{ cookiecutter.update({ "web_variant": False }) }}
+    {{ cookiecutter.update({ 'web_variant': 'n' }) }}
 {% endif %}
 
 API Variant
-{% if cookiecutter.variant in ["API only", "Both"] %}
-    {{ cookiecutter.update({ "api_variant": True }) }}
+{% if cookiecutter.variant in ['API only', 'Both'] %}
+    {{ cookiecutter.update({ 'api_variant': 'y' }) }}
 {% else %}
-    {{ cookiecutter.update({ "api_variant": False }) }}
+    {{ cookiecutter.update({ 'api_variant': 'n' }) }}
 {% endif %}
 
 -----------
@@ -23,15 +23,15 @@ CSS Addon
 cookiecutter.css_addon
 -----------
 Ignored unless a condition matches
-{{ cookiecutter.update({ "bootstrap_addon": False }) }}
-{{ cookiecutter.update({ "tailwinds_addon": False }) }}
+{{ cookiecutter.update({ 'bootstrap_addon': 'n' }) }}
+{{ cookiecutter.update({ 'tailwinds_addon': 'n' }) }}
 
 Only project with web:
-{% if cookiecutter.web_variant %}
-    {% if cookiecutter.css_addon == "Bootstrap" %}
-        {{ cookiecutter.update({ "bootstrap_addon": True }) }}
-    {% elif cookiecutter.css_addon == "Tailwinds" %}
-        {{ cookiecutter.update({ "tailwinds_addon": True }) }}
+{% if cookiecutter.web_variant == 'y' %}
+    {% if cookiecutter.css_addon == 'Bootstrap' %}
+        {{ cookiecutter.update({ 'bootstrap_addon': 'y' }) }}
+    {% elif cookiecutter.css_addon == 'Tailwinds' %}
+        {{ cookiecutter.update({ 'tailwinds_addon': 'y' }) }}
     {% endif %}
 {% endif %}
-"""
+'''

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,8 +1,9 @@
 """
-Setting easy to read/maintain variables:
+Setting easy to read/maintain cookiecutter variables:
 
 -----------
 Web Variant
+cookiecutter.web_addon
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
     {{ cookiecutter.update({ "web_variant": "y" }) }}
@@ -19,24 +20,18 @@ API Variant
 
 -----------
 CSS Addon
+cookiecutter.css_addon
 -----------
+Ignored unless a condition matches
+{{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
+{{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
+
 Only project with web:
 {% if cookiecutter.web_variant == 'y' %}
     {% if cookiecutter.css_addon == 'Bootstrap' %}
         {{ cookiecutter.update({ "bootstrap_addon": "y" }) }}
-        {{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
-    {% else %}
-        {% if cookiecutter.css_addon == 'Tailwinds' %}
-            {{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
-            {{ cookiecutter.update({ "tailwinds_addon": "y" }) }}
-        {% else %}
-            {{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
-            {{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
-        {% endif %}
+    {% elif cookiecutter.css_addon == 'Tailwinds' %}
+        {{ cookiecutter.update({ "tailwinds_addon": "y" }) }}
     {% endif %}
-Ignored for API only projects
-{% else %}
-    {{ cookiecutter.update({ "bootstrap_addon": "n" }) }}
-    {{ cookiecutter.update({ "tailwinds_addon": "n" }) }}
 {% endif %}
 """

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -7,12 +7,12 @@ cookiecutter._web_variant
 cookiecutter._api_variant
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
-    {{ cookiecutter.update({ '_web_variant': 'y' }) }}
+    {{ cookiecutter.update({ '_web_variant': 'yes' }) }}
 {% endif %}
 
 API Variant
 {% if cookiecutter.variant in ['API only', 'Both'] %}
-    {{ cookiecutter.update({ '_api_variant': 'y' }) }}
+    {{ cookiecutter.update({ '_api_variant': 'yes' }) }}
 {% endif %}
 
 -----------
@@ -22,11 +22,11 @@ cookiecutter._tailwinds_addon
 -----------
 
 Only project with web:
-{% if cookiecutter._web_variant == 'y' %}
+{% if cookiecutter._web_variant == 'yes' %}
     {% if cookiecutter.css_addon == 'Bootstrap' %}
-        {{ cookiecutter.update({ '_bootstrap_addon': 'y' }) }}
+        {{ cookiecutter.update({ '_bootstrap_addon': 'yes' }) }}
     {% elif cookiecutter.css_addon == 'Tailwinds' %}
-        {{ cookiecutter.update({ '_tailwinds_addon': 'y' }) }}
+        {{ cookiecutter.update({ '_tailwinds_addon': 'yes' }) }}
     {% endif %}
 {% endif %}
 '''

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -2,36 +2,31 @@
 Setting easy to read/maintain cookiecutter variables:
 
 -----------
-Web Variant
-cookiecutter.web_addon
+Web/API Variant
+cookiecutter._web_variant
+cookiecutter._api_variant
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
-    {{ cookiecutter.update({ 'web_variant': 'y' }) }}
-{% else %}
-    {{ cookiecutter.update({ 'web_variant': 'n' }) }}
+    {{ cookiecutter.update({ '_web_variant': 'y' }) }}
 {% endif %}
 
 API Variant
 {% if cookiecutter.variant in ['API only', 'Both'] %}
-    {{ cookiecutter.update({ 'api_variant': 'y' }) }}
-{% else %}
-    {{ cookiecutter.update({ 'api_variant': 'n' }) }}
+    {{ cookiecutter.update({ '_api_variant': 'y' }) }}
 {% endif %}
 
 -----------
-CSS Addon
-cookiecutter.css_addon
+CSS Addons
+cookiecutter._bootstrap_addon
+cookiecutter._tailwinds_addon
 -----------
-Ignored unless a condition matches
-{{ cookiecutter.update({ 'bootstrap_addon': 'n' }) }}
-{{ cookiecutter.update({ 'tailwinds_addon': 'n' }) }}
 
 Only project with web:
-{% if cookiecutter.web_variant == 'y' %}
+{% if cookiecutter._web_variant == 'y' %}
     {% if cookiecutter.css_addon == 'Bootstrap' %}
-        {{ cookiecutter.update({ 'bootstrap_addon': 'y' }) }}
+        {{ cookiecutter.update({ '_bootstrap_addon': 'y' }) }}
     {% elif cookiecutter.css_addon == 'Tailwinds' %}
-        {{ cookiecutter.update({ 'tailwinds_addon': 'y' }) }}
+        {{ cookiecutter.update({ '_tailwinds_addon': 'y' }) }}
     {% endif %}
 {% endif %}
 '''

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -38,7 +38,7 @@ install-dependencies:
 	go get github.com/pressly/goose/cmd/goose
 	go get github.com/ddollar/forego
 	go mod tidy
-	{% if cookiecutter._web_variant == "y" %}npm install{% endif %}
+	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
 
 test:
 	docker-compose -f docker-compose.test.yml up -d

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -38,7 +38,7 @@ install-dependencies:
 	go get github.com/pressly/goose/cmd/goose
 	go get github.com/ddollar/forego
 	go mod tidy
-	{% if cookiecutter.web_variant == "yes" %}npm install{% endif %}
+	{% if cookiecutter._web_variant == "y" %}npm install{% endif %}
 
 test:
 	docker-compose -f docker-compose.test.yml up -d

--- a/{{cookiecutter.app_name}}/Procfile.dev
+++ b/{{cookiecutter.app_name}}/Procfile.dev
@@ -1,2 +1,2 @@
 web: air -c cmd/api/.air.toml
-{% if cookiecutter.web_variant == "yes" %}snowpack: npm run dev{% endif %}
+{% if cookiecutter._web_variant == "y" %}snowpack: npm run dev{% endif %}

--- a/{{cookiecutter.app_name}}/Procfile.dev
+++ b/{{cookiecutter.app_name}}/Procfile.dev
@@ -1,2 +1,2 @@
 web: air -c cmd/api/.air.toml
-{% if cookiecutter._web_variant == "y" %}snowpack: npm run dev{% endif %}
+{% if cookiecutter._web_variant == "yes" %}snowpack: npm run dev{% endif %}

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -10,7 +10,7 @@
 
 - [Go - 1.16](https://golang.org/doc/go1.16) or newer
 
-{% if cookiecutter._web_variant == "y" %}- [Node - 14](https://nodejs.org/en/){% endif %}
+{% if cookiecutter._web_variant == "yes" %}- [Node - 14](https://nodejs.org/en/){% endif %}
 
 ### Development
 
@@ -26,7 +26,7 @@ To start the development server, `.env` file must be created.
 
 - [`goose`](https://github.com/pressly/goose) is used for database migration.
 
-{% if cookiecutter._web_variant == "y" %}- [`forego`](https://github.com/ddollar/forego) manages Procfile-based applications.{% endif %}
+{% if cookiecutter._web_variant == "yes" %}- [`forego`](https://github.com/ddollar/forego) manages Procfile-based applications.{% endif %}
 
 They need to be built as a binary file in `$GOPATH`.
 

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -10,7 +10,7 @@
 
 - [Go - 1.16](https://golang.org/doc/go1.16) or newer
 
-{% if cookiecutter.web_variant == "yes" %}- [Node - 14](https://nodejs.org/en/){% endif %}
+{% if cookiecutter._web_variant == "y" %}- [Node - 14](https://nodejs.org/en/){% endif %}
 
 ### Development
 
@@ -26,7 +26,7 @@ To start the development server, `.env` file must be created.
 
 - [`goose`](https://github.com/pressly/goose) is used for database migration.
 
-{% if cookiecutter.web_variant == "yes" %}- [`forego`](https://github.com/ddollar/forego) manages Procfile-based applications.{% endif %}
+{% if cookiecutter._web_variant == "y" %}- [`forego`](https://github.com/ddollar/forego) manages Procfile-based applications.{% endif %}
 
 They need to be built as a binary file in `$GOPATH`.
 

--- a/{{cookiecutter.app_name}}/bootstrap/router.go
+++ b/{{cookiecutter.app_name}}/bootstrap/router.go
@@ -2,7 +2,7 @@ package bootstrap
 
 import (
 	apiv1router "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/v1/routers"
-	{% if cookiecutter.web_variant == "yes" %}webrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/web/routers"{% endif %}
+	{% if cookiecutter._web_variant == "y" %}webrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/web/routers"{% endif %}
 
 	"github.com/gin-gonic/gin"
 )

--- a/{{cookiecutter.app_name}}/bootstrap/router.go
+++ b/{{cookiecutter.app_name}}/bootstrap/router.go
@@ -2,7 +2,7 @@ package bootstrap
 
 import (
 	apiv1router "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/v1/routers"
-	{% if cookiecutter._web_variant == "y" %}webrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/web/routers"{% endif %}
+	{% if cookiecutter._web_variant == "yes" %}webrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/web/routers"{% endif %}
 
 	"github.com/gin-gonic/gin"
 )


### PR DESCRIPTION
## What happened 👀

Issue: How can we have a cli prompt asking few multiple choice questions (which variant? which css addon) while having easy to use variable (web_variant = y/n, api_variant = y/n, bootstrap_variant = y/n, tailwinds_variant = y/n). 
 
## Insight 📝

Cookiecutter does not enable the following:
- Write template variable from python code in a hook (read only using the template injection)
- Assign calculated values for private variable (in cookiecutter.json, a varaible can start with `_` so it won't be prompted to the user). This will be fixed in a future release 2.0.0 thanks to [this commit](https://github.com/cookiecutter/cookiecutter/commit/623e4b9f03b36bcd0c69acc52046cc4d98baac41)

To solve this, I used a template hack recommended [here](https://github.com/samj1912/cookiecutter-advanced-demo/blob/master/hooks/pre_gen_project.py).
- We put a big comment in `hooks/pre_gen_project.py` file
- We use template syntax inside this comment to handle conditions 
- We call `cookiecutter.update( { "variable_name": "new_value" } )` to create or update a variable

When later we can update to cookiecutter 2.X, it would be wise to put this code back in `cookiecutter.json` file using private variables. 
 
## Proof Of Work 📹

| Choice variables used: | Template variable available: |
|---|---|
| ![image](https://user-images.githubusercontent.com/77609814/124211033-a8a3c280-db16-11eb-8d89-01562f0f085c.png) | ![image](https://user-images.githubusercontent.com/77609814/124211069-b8bba200-db16-11eb-99ed-9f400c6d54e6.png) |
| ![image](https://user-images.githubusercontent.com/77609814/124211226-f4566c00-db16-11eb-8ccc-a147e48325d3.png) | ![image](https://user-images.githubusercontent.com/77609814/124211246-00422e00-db17-11eb-82e2-6a5dbabfd41c.png) |
| ![image](https://user-images.githubusercontent.com/77609814/124211351-28ca2800-db17-11eb-9a62-c1825522fdab.png) | ![image](https://user-images.githubusercontent.com/77609814/124211380-32ec2680-db17-11eb-99d9-374c47cb0bfe.png) | 



