### PR TITLE
Refactor go cookiecutter

### DIFF
--- a/tests/cookiecutter.go
+++ b/tests/cookiecutter.go
@@ -1,0 +1,38 @@
+package tests
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type Choices string
+
+const (
+	Yes Choices = "1"
+	No  Choices = "2"
+)
+
+// Field and order MUST be the same as cookiecutter.json
+type Cookiecutter struct {
+	AppName string
+}
+
+func (c *Cookiecutter) fillDefaultValue() {
+	if len(c.AppName) == 0 {
+		c.AppName = "test-gin-templates"
+	}
+}
+
+func (c *Cookiecutter) structToString() string {
+	var structString strings.Builder
+
+	c.fillDefaultValue()
+
+	v := reflect.ValueOf(*c)
+	for i := 0; i < v.NumField(); i++ {
+		structString.WriteString(fmt.Sprintf("%v\n", v.Field(i)))
+	}
+
+	return structString.String()
+}

--- a/tests/template.go
+++ b/tests/template.go
@@ -1,22 +1,11 @@
 package tests
 
 import (
-	"fmt"
 	"io"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo"
 )
-
-// This should be consistent with cookiecutter.json
-type Cookiecutter struct {
-	AppName string
-}
-
-// String order MUST be consistent with cookiecutter.json
-func (c Cookiecutter) structToString() string {
-	return fmt.Sprintf("%v", c.AppName)
-}
 
 func (c Cookiecutter) CreateProjectFromGinTemplate(currentTemplatePath string) {
 	shCmd := exec.Command("cookiecutter", "../")


### PR DESCRIPTION
## What happened 👀

- Separate go cookiecutter to another file
- Add `fillDefaultValue()` function to fill the default value to the struct
- Convert manual `structToString()` function to use loop instead.
- Add custom type
 
## Insight 📝

- `fillDefaultValue()` is added because in case we have more than just `AppName`, for example, we need to add `UseLogrus` we don't need to add `UseLogrus` to all of the struct in the existing test, we can just add following code to `fillDefaultValue()`
```go
if c.UseLogrus != Yes && c.UseLogrus != No {
    c.UseLogrus = No
}
```
- Cookiecutter struct field and order MUST be the same as `cookiecutter.json` because cookiecutter will prompt the question in order we specify in `cookiecutter.json`
 
## Proof Of Work 📹

Run test was passed.
<img width="601" alt="Screen Shot 2564-07-02 at 18 27 38" src="https://user-images.githubusercontent.com/29707647/124268020-2f7e8c80-db63-11eb-8fee-d7440102e0da.png">
