### PR TITLE
#56 Add Bootstrap addons

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -796,4 +796,82 @@ var _ = Describe("Create template", func() {
 			Expect(content).NotTo(ContainSubstring(expectedContent))
 		})
 	})
+
+	Context("given bootstrap add-on", func() {
+		It("contains lib/web/assets/stylesheets/vendors/bootstrap folder", func() {
+			cookiecutter := tests.Cookiecutter{
+				Variant:  tests.Web,
+				CssAddon: tests.Bootstrap,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("lib/web/assets/stylesheets/vendors/bootstrap")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains bootstrap package in package.json", func() {
+			cookiecutter := tests.Cookiecutter{
+				Variant:  tests.Web,
+				CssAddon: tests.Bootstrap,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("package.json")
+
+			expectedContent := "\"bootstrap\": \"5.0.2\""
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+
+		It("contains bootstrap scss import in lib/web/assets/stylesheets/application.scss", func() {
+			cookiecutter := tests.Cookiecutter{
+				Variant:  tests.Web,
+				CssAddon: tests.Bootstrap,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("lib/web/assets/stylesheets/application.scss")
+
+			expectedContent := "@import \"./vendors/bootstrap\";"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+	})
+
+	Context("given NO bootstrap add-on", func() {
+		It("does NOT contain lib/web/assets/stylesheets/vendors/bootstrap folder", func() {
+			cookiecutter := tests.Cookiecutter{
+				Variant:  tests.Web,
+				CssAddon: tests.None,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("lib/web/assets/stylesheets/vendors/bootstrap")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contain bootstrap package in package.json", func() {
+			cookiecutter := tests.Cookiecutter{
+				Variant:  tests.Web,
+				CssAddon: tests.None,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("package.json")
+
+			expectedContent := "\"bootstrap\":"
+
+			Expect(content).NotTo(ContainSubstring(expectedContent))
+		})
+
+		It("does NOT contain bootstrap scss import in lib/web/assets/stylesheets/application.scss", func() {
+			cookiecutter := tests.Cookiecutter{
+				Variant:  tests.Web,
+				CssAddon: tests.None,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("lib/web/assets/stylesheets/application.scss")
+
+			expectedContent := "@import \"./vendors/bootstrap\";"
+
+			Expect(content).NotTo(ContainSubstring(expectedContent))
+		})
+	})
 })

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,11 @@
 {
   "app_name": "default-app-name",
   "variant": ["API only", "Web only", "Both"],
+  "css_addon": ["Bootstrap", "None"],
   "use_logrus": ["yes", "no"],
   "use_heroku": ["yes", "no"],
 
   "_api_variant": "no",
-  "_web_variant": "no"
+  "_web_variant": "no",
+  "_bootstrap_addon": "no"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -54,6 +54,11 @@ if '{{ cookiecutter.use_heroku }}'.lower() == 'no':
     remove_files("deploy/heroku")
     remove_file(".github/workflows/deploy.yml")
 
+# Remove bootstrap add-on if not seleted
+if '{{ cookiecutter._bootstrap_addon }}' == 'no':
+    print_log('Removing bootstrap add-on')
+    remove_files("lib/web/assets/stylesheets/vendors/bootstrap")
+
 # Remove web variant if not selected
 if '{{ cookiecutter._web_variant }}' == 'no':
     print_log('Removing web variant related files')

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -14,4 +14,15 @@ API Variant
 {% if cookiecutter.variant in ['API only', 'Both'] %}
     {{ cookiecutter.update({ '_api_variant': 'yes' }) }}
 {% endif %}
+
+-----------
+CSS Addons
+cookiecutter._bootstrap_addon
+-----------
+Only project with web:
+{% if cookiecutter._web_variant == 'yes' %}
+    {% if cookiecutter.css_addon == 'Bootstrap' %}
+        {{ cookiecutter.update({ '_bootstrap_addon': 'yes' }) }}
+    {% endif %}
+{% endif %}
 '''

--- a/tests/cookiecutter.go
+++ b/tests/cookiecutter.go
@@ -8,6 +8,7 @@ import (
 
 type Choices string
 type Variants string
+type CssAddons string
 
 const (
 	Yes Choices = "1"
@@ -16,12 +17,16 @@ const (
 	API  Variants = "1"
 	Web  Variants = "2"
 	Both Variants = "3"
+
+	Bootstrap CssAddons = "1"
+	None      CssAddons = "2"
 )
 
 // Field and order MUST be the same as cookiecutter.json
 type Cookiecutter struct {
 	AppName   string
 	Variant   Variants
+	CssAddon  CssAddons
 	UseLogrus Choices
 	UseHeroku Choices
 }
@@ -37,6 +42,10 @@ func (c *Cookiecutter) fillDefaultValue() {
 
 	if c.UseHeroku != Yes && c.UseHeroku != No {
 		c.UseHeroku = No
+	}
+
+	if c.CssAddon != Bootstrap && c.CssAddon != None {
+		c.CssAddon = None
 	}
 
 	if c.Variant != API && c.Variant != Web && c.Variant != Both {

--- a/{{cookiecutter.app_name}}/lib/web/assets/stylesheets/application.scss
+++ b/{{cookiecutter.app_name}}/lib/web/assets/stylesheets/application.scss
@@ -2,7 +2,8 @@
 @import './variables';
 
 // Vendors
-
+{% if cookiecutter._bootstrap_addon == "yes" %}@import "./vendors/bootstrap";
+{% endif %}
 // Functions
 @import './functions/sizing';
 

--- a/{{cookiecutter.app_name}}/lib/web/assets/stylesheets/vendors/bootstrap/index.scss
+++ b/{{cookiecutter.app_name}}/lib/web/assets/stylesheets/vendors/bootstrap/index.scss
@@ -1,0 +1,43 @@
+// 1. Include functions first (so you can manipulate colors, SVGs, calc, etc)
+@import "./bootstrap/scss/functions";
+
+// 2. Include remainder of required Bootstrap stylesheets
+@import "./node_modules/bootstrap/scss/variables";
+@import "./node_modules/bootstrap/scss/mixins";
+
+// 3. Include any optional Bootstrap components as you like
+//    Uncomment only the needed components
+
+@import "./node_modules/bootstrap/scss/root";
+@import "./node_modules/bootstrap/scss/reboot";
+@import "./node_modules/bootstrap/scss/type";
+@import "./node_modules/bootstrap/scss/containers";
+@import "./node_modules/bootstrap/scss/grid";
+
+// @import "./node_modules/bootstrap/scss/accordion";
+// @import "./node_modules/bootstrap/scss/alert";
+// @import "./node_modules/bootstrap/scss/badge";
+// @import "./node_modules/bootstrap/scss/breadcrumb";
+// @import "./node_modules/bootstrap/scss/buttons";
+// @import "./node_modules/bootstrap/scss/button-group";
+// @import "./node_modules/bootstrap/scss/card";
+// @import "./node_modules/bootstrap/scss/carousel";
+// @import "./node_modules/bootstrap/scss/close";
+// @import "./node_modules/bootstrap/scss/dropdown";
+// @import "./node_modules/bootstrap/scss/forms";
+// @import "./node_modules/bootstrap/scss/helpers";
+// @import "./node_modules/bootstrap/scss/images";
+// @import "./node_modules/bootstrap/scss/list-group";
+// @import "./node_modules/bootstrap/scss/modal";
+// @import "./node_modules/bootstrap/scss/nav";
+// @import "./node_modules/bootstrap/scss/navbar";
+// @import "./node_modules/bootstrap/scss/offcanvas";
+// @import "./node_modules/bootstrap/scss/pagination";
+// @import "./node_modules/bootstrap/scss/popover";
+// @import "./node_modules/bootstrap/scss/progress";
+// @import "./node_modules/bootstrap/scss/spinners";
+// @import "./node_modules/bootstrap/scss/tables";
+// @import "./node_modules/bootstrap/scss/toasts";
+// @import "./node_modules/bootstrap/scss/tooltip";
+// @import "./node_modules/bootstrap/scss/transitions";
+// @import "./node_modules/bootstrap/scss/utilities";

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -14,12 +14,13 @@
     "@snowpack/plugin-postcss": "1.4.3",
     "@snowpack/plugin-sass": "1.4.0",
     "@types/node": "15.12.5",
-    "autoprefixer": "10.2.6",
+    "autoprefixer": "10.2.6",{% if cookiecutter._bootstrap_addon == "yes" %}
+    "bootstrap": "5.0.2",{% endif %}
     "eslint": "7.29.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",
-    "prettier": "2.3.2",
     "postcss": "8.3.5",
+    "prettier": "2.3.2",
     "snowpack": "3.7.1"
   }
 }


### PR DESCRIPTION
- #56 

## What happened 👀

- [x] Add bootstrap add-on
- [x] Add tests
- [x] Review code
- [x] Fill in Proof Of Work
 
## Insight 📝

- Bootstrap version 5.0.2
- Using scss, most of the components are commented to enforce an `opt-in` approach
 
## Proof Of Work 📹

### Bootstrap Project from template:

Configured following readme 3x steps (.env file, make install-dependencies & make dev).

- No error/warning
    ![image](https://user-images.githubusercontent.com/77609814/126932595-e3062de0-0813-43b8-94e3-f44bd27365ec.png)

- Contains bootstrap css in bundle
    ![image](https://user-images.githubusercontent.com/77609814/126932420-2b9e4804-d38d-4fa5-852c-ff9881caff00.png)

- Ready to use bootstrap classes:
    ![image](https://user-images.githubusercontent.com/77609814/126932525-fb0fc460-6226-4c2b-a88c-03aab299429a.png)

### Tests are passing & covering added file & content

> 3x tests when bootstrap add-on is selected, 3 opposite tests when not selected

![image](https://user-images.githubusercontent.com/77609814/126931101-2dcf988a-5517-4e19-b94b-c1f265bfbf38.png)