### PR TITLE
Add Repository Add-on

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,11 +2,15 @@
   "app_name": "default-app-name",
   "variant": ["API only", "Web only", "Both"],
   "css_addon": ["Bootstrap", "Tailwind", "None"],
+  "repository_addon": ["GitHub", "GitLab", "None"],
   "use_logrus": ["yes", "no"],
   "use_heroku": ["yes", "no"],
 
   "_api_variant": "no",
   "_web_variant": "no",
   "_bootstrap_addon": "no",
-  "_tailwind_addon": "no"
+  "_tailwind_addon": "no",
+  "_github_addon": "no",
+  "_gitlab_addon": "no",
+  "_gitignore_addon": "yes"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -65,6 +65,21 @@ if '{{ cookiecutter._tailwind_addon }}' == 'no':
     remove_files("lib/web/assets/stylesheets/vendors/tailwind")
     remove_file("tailwind.config.js")
 
+# Remove github repository add-on if not seleted
+if '{{ cookiecutter._github_addon }}' == 'no':
+    print_log('Removing github repository add-on')
+    remove_files(".github")
+
+# Remove gitlab repository add-on if not seleted
+if '{{ cookiecutter._gitlab_addon }}' == 'no':
+    print_log('Removing gitlab repository add-on')
+    remove_files(".gitlab")
+
+# Remove .gitignore if not seleted any repository options
+if '{{ cookiecutter._gitignore_addon }}' == 'no':
+    print_log('Removing .gitignore')
+    remove_file("tailwind.config.js")
+
 # Remove web variant if not selected
 if '{{ cookiecutter._web_variant }}' == 'no':
     print_log('Removing web variant related files')

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -28,4 +28,18 @@ Only project with web:
         {{ cookiecutter.update({ '_tailwind_addon': 'yes' }) }}
     {% endif %}
 {% endif %}
+
+-----------
+Repository Addons
+cookiecutter._github_addon
+cookiecutter._gitlab_addon
+cookiecutter._gitignore_addon
+-----------
+{% if cookiecutter.repository_addon == 'GitHub' %}
+    {{ cookiecutter.update({ '_github_addon': 'yes' }) }}
+{% elif cookiecutter.repository_addon == 'GitLab' %}
+    {{ cookiecutter.update({ '_gitlab_addon': 'yes' }) }}
+{% elif cookiecutter.repository_addon == 'None' %}
+    {{ cookiecutter.update({ '_gitignore_addon': 'no' }) }}
+{% endif %}
 '''

--- a/{{cookiecutter.app_name}}/.gitlab/merge_request_templates/Default.md
+++ b/{{cookiecutter.app_name}}/.gitlab/merge_request_templates/Default.md
@@ -1,4 +1,4 @@
-https://github.com/nimblehq/git-template/issues/??
+https://project-management-tool/browse/??
 
 ## What happened 👀
 

--- a/{{cookiecutter.app_name}}/.gitlab/merge_request_templates/Release.md
+++ b/{{cookiecutter.app_name}}/.gitlab/merge_request_templates/Release.md
@@ -1,0 +1,19 @@
+Link to the milestone on GitLab
+or
+Link to the project management tool for the release
+
+## Features
+
+Provide the ID and title of the issue in the section for each type (feature, chore and bug). The link is optional.
+
+- [PMT-1234] As a user, I can log in
+or
+- [[PMT-1234]](https:///project-management-tool/browse/PMT-1234)] As a user, I can log in
+
+## Chores
+
+- Same structure as in  ## Feature
+
+## Bugs
+
+- Same structure as in  ## Feature


### PR DESCRIPTION
## What happened 👀

As we already had some [templates for GitHub](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) before.
I think we should apply this convenient for the other repository such as `GitLab` ☺️
Luckily, GitLab also has this folder convention for the [template](https://docs.gitlab.com/ee/user/project/description_templates.html).
 
## Insight 📝

- Add `GitLab` merge request templates
- Update repository add-on option into the cookie-cutter flow
 
## Proof Of Work 📹


