### PR TITLE
Add chore git template and clean up markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -8,13 +8,13 @@ labels: "type : bug"
 ## Issue
 
 Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
- 
+
 ## Expected
 
 Describe what should be the correct behaviour.
- 
+
 ## Steps to reproduce
 
-1. 
-2. 
-3. 
+1.
+2.
+3.

--- a/.github/ISSUE_TEMPLATE/chore_template.md
+++ b/.github/ISSUE_TEMPLATE/chore_template.md
@@ -1,0 +1,14 @@
+---
+name: "Chore"
+about: "Open a Chore for minor update."
+title: "Update "
+labels: "type : chore"
+---
+
+## Why
+
+Describe the update details and why it's needed.
+
+## Who Benefits?
+
+Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_template.md
@@ -7,8 +7,8 @@ labels: "type : feature"
 
 ## Why
 
-Describe the big picture of the feature and why it's needed. 
- 
+Describe the big picture of the feature and why it's needed.
+
 ## Who Benefits?
 
 Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,12 @@ https://github.com/nimblehq/git-template/issues/??
 
 ## What happened 👀
 
-Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
- 
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+
 ## Insight 📝
 
 Describe in details how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
- 
+
 ## Proof Of Work 📹
 
 Show us the implementation: screenshots, gif, etc.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ---
 
-Our templates offer a rich boilerplate to jump start Go Gin-based application development.
+Our templates offer a rich boilerplate to jump start Go [Gin-based](https://github.com/gin-gonic/gin) application development.
 
 Check this [wiki](https://github.com/nimblehq/gin-templates/wiki/Directories) for more information about the template structure.
 
@@ -25,16 +25,19 @@ Check this [wiki](https://github.com/nimblehq/gin-templates/wiki/Directories) fo
 ## Usage
 
 - Download **latest** version of gin-templates.
+
   ```
   go get github.com/nimblehq/gin-templates
   ```
 
 - Build the binary file.
+
   ```
   go build -o $GOPATH/bin/nimble-gin github.com/nimblehq/gin-templates
   ```
 
 - Create the project using gin-templates. Note that the **main** branch is being used by default. Refer to [this wiki page](https://github.com/nimblehq/gin-templates/wiki/Commands) for instructions on how to use a different branch.
+
   ```
   nimble-gin create
   ```
@@ -54,7 +57,7 @@ make test
 This project is Copyright (c) 2014 and onwards Nimble. It is free software,
 and may be redistributed under the terms specified in the [LICENSE] file.
 
-[LICENSE]: /LICENSE
+[license]: /LICENSE
 
 ## About
 

--- a/{{cookiecutter.app_name}}/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/{{cookiecutter.app_name}}/.github/ISSUE_TEMPLATE/bug_template.md
@@ -8,13 +8,13 @@ labels: "type : bug"
 ## Issue
 
 Describe the issue you are facing. Show us the implementation: screenshots, gif, etc.
- 
+
 ## Expected
 
 Describe what should be the correct behaviour.
- 
+
 ## Steps to reproduce
 
-1. 
-2. 
-3. 
+1.
+2.
+3.

--- a/{{cookiecutter.app_name}}/.github/ISSUE_TEMPLATE/feature_template.md
+++ b/{{cookiecutter.app_name}}/.github/ISSUE_TEMPLATE/feature_template.md
@@ -7,8 +7,8 @@ labels: "type : feature"
 
 ## Why
 
-Describe the big picture of the feature and why it's needed. 
- 
+Describe the big picture of the feature and why it's needed.
+
 ## Who Benefits?
 
 Describe who will be the beneficiaries e.g. everyone, specific chapters, clients...

--- a/{{cookiecutter.app_name}}/.github/PULL_REQUEST_TEMPLATE.md
+++ b/{{cookiecutter.app_name}}/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,12 +2,12 @@ https://github.com/nimblehq/git-template/issues/??
 
 ## What happened 👀
 
-Describe the big picture of your changes here to communicate to the team why we should accept this pull request. 
- 
+Describe the big picture of your changes here to communicate to the team why we should accept this pull request.
+
 ## Insight 📝
 
 Describe in details how to test the changes, which solution you tried but did not go with, referenced documentation is welcome as well.
- 
+
 ## Proof Of Work 📹
 
 Show us the implementation: screenshots, gif, etc.


### PR DESCRIPTION
## What happened 👀

We have [chore issue template](https://github.com/nimblehq/git-template/blob/main/.github/ISSUE_TEMPLATE/chore_template.md) in our Git template repo. The android team added it in the [Android template](https://github.com/nimblehq/android-templates/blob/develop/.github/ISSUE_TEMPLATE/chore_template.md) too. So we need to add here too.
 
## Insight 📝

The chore issue template file is the same as our Git [chore issue template](https://github.com/nimblehq/git-template/blob/main/.github/ISSUE_TEMPLATE/chore_template.md) file
 
## Proof Of Work 📹

![Screen Shot 2022-03-16 at 11 36 26 AM](https://user-images.githubusercontent.com/6076762/158517548-6d8df618-dd05-4a82-8d7b-76cd5d9cb240.png)

