### PR TITLE
[#78] Fix: golangci-lint-action failing in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
           go-version: 1.16.x
 
       - name: Linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.45
 
       - name: Test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2.3.4
 

--- a/{{cookiecutter.app_name}}/.github/workflows/deploy.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/deploy.yml
@@ -17,6 +17,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: {{ "${{ github.token }}" }}
+
       - name: Checkout
         uses: actions/checkout@v2.3.4
 

--- a/{{cookiecutter.app_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
         run: cp ".env.example" ".env"
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.29
+          version: v1.45
 
       - name: Install dependencies
         run: make install-dependencies

--- a/{{cookiecutter.app_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/test.yml
@@ -6,7 +6,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out Git repository
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: {{ "${{ github.token }}" }}
+
+      - name: Checkout
         uses: actions/checkout@v2.3.4
 
       - name: Setup Go


### PR DESCRIPTION
Resolve https://github.com/nimblehq/gin-templates/issues/78

## What happened 👀

- The `golangci-lint-action` failed for an unknown reason.
- Update the `golangci-lint-action` to the latest version.
- Add [`cancel-workflow-action`](https://github.com/styfle/cancel-workflow-action) to cancel previous workflow runs

## Insight 📝

N/A

## Proof Of Work 📹

Tests should be passed:
https://github.com/nimblehq/gin-templates/runs/6206707238?check_suite_focus=true
