### PR TITLE
[#80] Add script to initialize git and create the first commit

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,8 +1,10 @@
 import os
 import shutil
+import subprocess
 
 # Get the root project directory
 PROJECT_DIRECTORY = os.path.realpath(os.path.curdir)
+
 
 def remove_files(path):
     """
@@ -11,6 +13,7 @@ def remove_files(path):
     shutil.rmtree(os.path.join(
         PROJECT_DIRECTORY, path
     ))
+
 
 def remove_file(path):
     """
@@ -21,6 +24,8 @@ def remove_file(path):
     ))
 
 # Print log with color
+
+
 def print_log(message):
     """
     Print log with color
@@ -28,6 +33,7 @@ def print_log(message):
     CYELLOW = '\33[33m'  # YELLOW color
     CEND = '\033[0m'  # END color
     print(CYELLOW + message + CEND)
+
 
 def remove_empty_folders():
     """
@@ -39,6 +45,17 @@ def remove_empty_folders():
                 if (len(os.listdir(os.path.join(root, dir))) == 0):
                     print_log(f'Removing {dir} folder')
                     os.rmdir(os.path.join(root, dir))
+
+
+def init_git(message):
+    """
+    Initialize git repository
+    """
+    print_log(message)
+    subprocess.call(['git', 'init'])
+    subprocess.call(['git', 'add', '*'])
+    subprocess.call(
+        ['git', 'commit', '-m', 'Initialize project using gin-templates'])
 
 
 # Remove logrus add-on if not seleted
@@ -71,7 +88,7 @@ if '{{ cookiecutter._web_variant }}' == 'no':
 
     # Web folder
     remove_files('lib/web')
-    
+
     # Config files
     remove_file('.eslintrc.json')
     remove_file('.npmrc')
@@ -82,11 +99,14 @@ if '{{ cookiecutter._web_variant }}' == 'no':
 
 # Download the missing dependencies
 print_log('Downloading dependencies')
-os.system("go mod tidy")
+subprocess.call(['go', 'mod', 'tidy'])
 
 # Format code
 print_log('Formating code')
-os.system("go fmt ./...")
+subprocess.call(['go', 'fmt', './...'])
 
 # Remove empty folders
 remove_empty_folders()
+
+# Initialize git
+init_git('Initializing git repository')


### PR DESCRIPTION
Resolve https://github.com/nimblehq/gin-templates/issues/80

## What happened 👀

Add scripts to initialize git repository after creating project

## Insight 📝

Change to use `subprocess.call` instead of `os.system` as `os.system` was deprecated
https://mail.python.org/pipermail/python-dev/2018-October/155563.html

## Proof Of Work 📹
Tested on my local:
<details>
  <summary>Click to expand!</summary>
  
```
➜  nimble-gin create
app_name [default-app-name]:test-init-git
Select variant:
1 - API only
2 - Web only
3 - Both
Choose from 1, 2, 3 [1]:1
Select css_addon:
1 - Bootstrap
2 - Tailwind
3 - None
Choose from 1, 2, 3 [1]:1
Select use_logrus:
1 - yes
2 - no
Choose from 1, 2 [1]:1
Select use_heroku:
1 - yes
2 - no
Choose from 1, 2 [1]:1
Removing bootstrap add-on
Removing tailwind add-on
Removing web variant related files
Downloading dependencies
Formating code
bootstrap/config.go
bootstrap/database.go
bootstrap/router.go
test/test.go
Initializing git
Initialized empty Git repository in /Users/mirs/Documents/Nimble/Projects/internal/test-init-git/.git/
[main (root-commit) 99298b9] Initialize project using gin-templates
 46 files changed, 1655 insertions(+)
 create mode 100644 .env.example
 create mode 100644 .env.test
 create mode 100644 .github/ISSUE_TEMPLATE/bug_template.md
 create mode 100644 .github/ISSUE_TEMPLATE/feature_template.md
 create mode 100644 .github/PULL_REQUEST_TEMPLATE.md
 create mode 100644 .github/workflows/deploy.yml
 create mode 100644 .github/workflows/test.yml
 create mode 100644 .gitignore
 create mode 100644 Dockerfile
 create mode 100644 Makefile
 create mode 100644 Procfile.dev
 create mode 100644 README.md
 create mode 100755 bin/wait-for-postgres.sh
 create mode 100644 bootstrap/config.go
 create mode 100644 bootstrap/database.go
 create mode 100644 bootstrap/router.go
 create mode 100644 cmd/api/.air.toml
 create mode 100644 cmd/api/main.go
 create mode 100644 config/app.toml
 create mode 100644 database/migrations/.keep
 create mode 100644 deploy/heroku/config.tf
 create mode 100644 deploy/heroku/main.tf
 create mode 100644 deploy/heroku/terraform.tfvars.sample
 create mode 100644 deploy/heroku/variables.tf
 create mode 100644 docker-compose.dev.yml
 create mode 100644 docker-compose.test.yml
 create mode 100644 go.mod
 create mode 100644 go.sum
 create mode 100644 helpers/config.go
 create mode 100644 helpers/config_test.go
 create mode 100644 helpers/helpers_suite_test.go
 create mode 100644 helpers/log/log.go
 create mode 100644 lib/api/v1/controllers/base.go
 create mode 100644 lib/api/v1/controllers/controllers_suite_test.go
 create mode 100644 lib/api/v1/controllers/health.go
 create mode 100644 lib/api/v1/controllers/health_test.go
 create mode 100644 lib/api/v1/forms/.keep
 create mode 100644 lib/api/v1/routers/router.go
 create mode 100644 lib/api/v1/serializers/.keep
 create mode 100644 lib/middlewares/.keep
 create mode 100644 lib/models/.keep
 create mode 100644 lib/services/.keep
 create mode 100644 test/factories/.keep
 create mode 100644 test/fixtures/.keep
 create mode 100644 test/http.go
 create mode 100644 test/test.go
2022/04/28 17:02:40 Gin project created successfully.
```
</details>