### PR TITLE
[#91] Fix: Move database migration right after the database initializing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Team
-# @junan is the Team Lead and the others are team members
-* @junan @carryall @hoangmirs @Lahphim @malparty
+# @carryall is the Team Lead and the others are team members
+* @carryall @hoangmirs @malparty @Nihisil @suphanatjarukulgowit
 
 # Engineering Leads
 CODEOWNERS @nimblehq/engineering-leads

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ Check this [wiki](https://github.com/nimblehq/gin-templates/wiki/Directories) fo
 
 - Download **latest** version of gin-templates.
 
-  ```
+  ```sh
   go get github.com/nimblehq/gin-templates
   ```
 
 - Build the binary file.
 
-  ```
+  ```sh
   go build -o $GOPATH/bin/nimble-gin github.com/nimblehq/gin-templates
   ```
 
 - Create the project using gin-templates. Note that the **main** branch is being used by default. Refer to [this wiki page](https://github.com/nimblehq/gin-templates/wiki/Commands) for instructions on how to use a different branch.
 
-  ```
+  ```sh
   nimble-gin create
   ```
 

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -125,13 +125,13 @@ var _ = Describe("Create template", func() {
 	})
 
 	Context("given bootstrap/database.go", func() {
-		It("contains project name at helpers import", func() {
+		It("contains project name at database import", func() {
 			cookiecutter := tests.Cookiecutter{AppName: "test-gin-templates"}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 
 			content := tests.ReadFile("bootstrap/database.go")
 
-			expectedContent := `"github.com/nimblehq/test-gin-templates/helpers"`
+			expectedContent := `"github.com/nimblehq/test-gin-templates/database"`
 
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
@@ -296,7 +296,7 @@ var _ = Describe("Create template", func() {
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile("go.mod")
 
-			expectedContent := "github.com/sirupsen/logrus v1.8.1"
+			expectedContent := "github.com/sirupsen/logrus"
 
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
@@ -314,13 +314,26 @@ var _ = Describe("Create template", func() {
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
 
-		It("contains logrus package import in bootstrap/database.go", func() {
+		Context("given database/database.go", func() {
+			It("contains project name at helpers import", func() {
+				cookiecutter := tests.Cookiecutter{AppName: "test-gin-templates"}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+
+				content := tests.ReadFile("database/database.go")
+
+				expectedContent := `"github.com/nimblehq/test-gin-templates/helpers"`
+
+				Expect(content).To(ContainSubstring(expectedContent))
+			})
+		})
+
+		It("contains logrus package import in database/database.go", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName:   "test-gin-templates",
 				UseLogrus: tests.Yes,
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile("bootstrap/database.go")
+			content := tests.ReadFile("database/database.go")
 
 			expectedContent := "github.com/nimblehq/test-gin-templates/helpers/log"
 

--- a/{{cookiecutter.app_name}}/Dockerfile
+++ b/{{cookiecutter.app_name}}/Dockerfile
@@ -1,7 +1,5 @@
 FROM golang:1.18-buster
 
-ARG DATABASE_URL
-
 ENV GIN_MODE=release
 
 WORKDIR /app
@@ -10,14 +8,8 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
-# Install goose for migration
-RUN go get github.com/pressly/goose/cmd/goose
-
 # Copy codebase
 COPY . .
-
-# Run the migration
-RUN goose -dir database/migrations -table "migration_versions" postgres "$DATABASE_URL" up
 
 # Build go application
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o main ./cmd/api

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -34,15 +34,15 @@ dev:
 	forego start -f Procfile.dev
 
 install-dependencies:
-	go get github.com/cosmtrek/air@v1.15.1
-	go get github.com/pressly/goose/cmd/goose
-	go get github.com/ddollar/forego
+	go install github.com/cosmtrek/air@v1.41.1
+	go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
+	go install github.com/ddollar/forego@latest
 	go mod tidy
 	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
 
 test:
 	docker-compose -f docker-compose.test.yml up -d
-	ENV=test make db/migrate
+	make wait-for-postgres
 	go test -v -p 1 -count=1 ./...
 	docker-compose -f docker-compose.test.yml down
 

--- a/{{cookiecutter.app_name}}/bootstrap/bootstrap.go
+++ b/{{cookiecutter.app_name}}/bootstrap/bootstrap.go
@@ -4,6 +4,8 @@ import (
 	"github.com/nimblehq/{{cookiecutter.app_name}}/database"
 )
 
-func InitDatabase(databaseURL string) {
-	database.InitDatabase(databaseURL)
+func Init() {
+	LoadConfig()
+
+	InitDatabase(database.GetDatabaseURL())
 }

--- a/{{cookiecutter.app_name}}/cmd/api/main.go
+++ b/{{cookiecutter.app_name}}/cmd/api/main.go
@@ -12,9 +12,7 @@ import (
 )
 
 func main() {
-	bootstrap.LoadConfig()
-
-	bootstrap.InitDatabase()
+	bootstrap.Init()
 
 	r := bootstrap.SetupRouter()
 

--- a/{{cookiecutter.app_name}}/database/database.go
+++ b/{{cookiecutter.app_name}}/database/database.go
@@ -1,0 +1,68 @@
+package database
+
+import (
+	"fmt"
+	"strings"
+	{% if cookiecutter.use_logrus == "no" %}"log"
+	{% endif %}
+
+	"github.com/nimblehq/{{cookiecutter.app_name}}/helpers"
+	{% if cookiecutter.use_logrus == "yes" %}"github.com/nimblehq/{{cookiecutter.app_name}}/helpers/log"
+	{% endif %}
+
+	"github.com/gin-gonic/gin"
+	"github.com/pressly/goose/v3"
+	"github.com/spf13/viper"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+var database *gorm.DB
+
+func InitDatabase(databaseURL string) {
+	db, err := gorm.Open(postgres.Open(databaseURL), &gorm.Config{})
+	if err != nil {
+		log.Fatalf("Failed to connect to %v database: %v", gin.Mode(), err)
+	} else {
+		viper.Set("database", db)
+		log.Println(strings.Title(gin.Mode()) + " database connected successfully.")
+	}
+
+	migrateDB(db)
+}
+
+func migrateDB(db *gorm.DB) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		log.Fatalf("Failed to convert gormDB to sqlDB: %v", err)
+	}
+
+	err = goose.Up(sqlDB, "database/migrations", goose.WithAllowMissing())
+	if err != nil {
+		log.Fatalf("Failed to migrate database: %v", err)
+	}
+
+	log.Println("Migrated database successfully.")
+}
+
+func GetDB() *gorm.DB {
+	if database == nil {
+		InitDatabase(GetDatabaseURL())
+	}
+
+	return database
+}
+
+func GetDatabaseURL() string {
+	if gin.Mode() == gin.ReleaseMode {
+		return viper.GetString("DATABASE_URL")
+	}
+
+	return fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=disable",
+		viper.GetString("db_username"),
+		viper.GetString("db_password"),
+		viper.GetString("db_host"),
+		helpers.GetStringConfig("db_port"),
+		helpers.GetStringConfig("db_name"),
+	)
+}


### PR DESCRIPTION
Resolve https://github.com/nimblehq/gin-templates/issues/91

## What happened 👀

Move the database migration right after the [database is initialized](https://github.com/nimblehq/gulf-approval-web/blob/develop/bootstrap/database.go#L17), just like we did in [Varun API project](https://github.com/nimblehq/varun-api/blob/develop/database/database.go#L33)

## Insight 📝

N/A

## Proof Of Work 📹

All test passed
