### PR TITLE
[#93] Replace `docker-compose` with `docker compose`

### DIFF
--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -6,10 +6,10 @@ endif
 .PHONY: env-setup env-teardown db/migrate db/rollback migration/create migration/status dev install-dependencies test wait-for-postgres
 
 env-setup:
-	docker-compose -f docker-compose.dev.yml up -d
+	docker compose -f docker-compose.dev.yml up -d
 
 env-teardown:
-	docker-compose -f docker-compose.dev.yml down
+	docker compose -f docker-compose.dev.yml down
 
 db/migrate:
 	make wait-for-postgres
@@ -41,10 +41,10 @@ install-dependencies:
 	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
 
 test:
-	docker-compose -f docker-compose.test.yml up -d
+	docker compose -f docker-compose.test.yml up -d
 	make wait-for-postgres
 	go test -v -p 1 -count=1 ./... -coverprofile=coverage/coverage.out -ginkgo.reportFile=coverage/test-report.xml
-	docker-compose -f docker-compose.test.yml down
+	docker compose -f docker-compose.test.yml down
 
 coverage:
 	go tool cover -html=coverage/coverage.out -o coverage/coverage.html


### PR DESCRIPTION
Resolve https://github.com/nimblehq/gin-templates/issues/93

## What happened 👀

Replace `docker-compose` command regarding the [migration from docker compose v1 to v2](https://docs.docker.com/compose/migrate/)

## Insight 📝

N/A

## Proof Of Work 📹

Tested the change on existing project

https://github.com/nimblehq/gin-templates/assets/1772999/6545ad1c-e73b-46c0-b3d4-3d6c32f554da



