### PR TITLE
[#90] Fix: Deprecate Title of strings, bytes modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Check this [wiki](https://github.com/nimblehq/gin-templates/wiki/Directories) fo
 make test
 ```
 
+## Development
+
+- Build the command with
+
+  ```sh
+  go build -o <PATH_TO_STORE_BUILD_FILE>
+  ```
+
+- Run the build file follow by the `create` command and the prompt to create a Go project should appear
+
+  ```sh
+  <PATH_TO_STORE_BUILD_FILE> create
+  ```
+
 ## License
 
 This project is Copyright (c) 2014 and onwards Nimble. It is free software,

--- a/{{cookiecutter.app_name}}/database/database.go
+++ b/{{cookiecutter.app_name}}/database/database.go
@@ -2,7 +2,6 @@ package database
 
 import (
 	"fmt"
-	"strings"
 	{% if cookiecutter.use_logrus == "no" %}"log"
 	{% endif %}
 
@@ -13,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/pressly/goose/v3"
 	"github.com/spf13/viper"
+	"golang.org/x/text/cases"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -25,7 +25,8 @@ func InitDatabase(databaseURL string) {
 		log.Fatalf("Failed to connect to %v database: %v", gin.Mode(), err)
 	} else {
 		viper.Set("database", db)
-		log.Println(strings.Title(gin.Mode()) + " database connected successfully.")
+		caser := cases.Title(language.English)
+		log.Println(caser.String(gin.Mode()) + " database connected successfully.")
 	}
 
 	migrateDB(db)


### PR DESCRIPTION
Resolve https://github.com/nimblehq/gin-templates/issues/90

## What happened 👀

[The `strings.Title` is deprecated on Go 1.18](https://stackoverflow.com/questions/71620717/in-go-1-18-strings-title-is-deprecated-what-to-use-now-and-how), `cases.Title` is used instead

## Insight 📝

N/A

## Proof Of Work 📹

No error when creating a new project with the new changes

![Screenshot 2566-05-26 at 16 11 55](https://github.com/nimblehq/gin-templates/assets/1772999/c139382c-8da6-4733-b3f5-b83bad5b5bc8)

