### PR TITLE
[#103]Fix: Upgrade the Air version as the Air@v1.41.1 has been removed

### DIFF
--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -34,7 +34,7 @@ dev:
 	forego start -f Procfile.dev
 
 install-dependencies:
-	go install github.com/cosmtrek/air@v1.41.1
+	go install github.com/cosmtrek/air@v1.43.0
 	go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 	go install github.com/ddollar/forego@latest
 	go mod tidy


### PR DESCRIPTION
Resolve https://github.com/nimblehq/gin-templates/issues/103

## What happened 👀

Upgrade [cosmtrek/air](https://github.com/cosmtrek/air) version to remove error when install dependencies

## Insight 📝

N/A

## Proof Of Work 📹

-- | Preview
--- | ---
Before | ![Screenshot 2566-06-01 at 17 44 46](https://github.com/nimblehq/gin-templates/assets/1772999/c326d4c6-f073-4564-9531-e2fe2eb56948)
After | ![Screenshot 2566-06-01 at 17 45 22](https://github.com/nimblehq/gin-templates/assets/1772999/6c36b38c-d788-4915-9e11-8e44f3ff28d1)
