### PR TITLE
[#105] [Part 1] Add OpenAPI to support creating API documentation with OpenAPI

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -690,17 +690,6 @@ var _ = Describe("Create template", func() {
 			Expect(os.IsNotExist(err)).To(BeTrue())
 		})
 
-		It("does NOT contain .eslintrc.json file", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName: "test-gin-templates",
-				Variant: tests.API,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			_, err := os.Stat(".eslintrc.json")
-
-			Expect(os.IsNotExist(err)).To(BeTrue())
-		})
-
 		It("does NOT contain .npmrc file", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName: "test-gin-templates",
@@ -708,17 +697,6 @@ var _ = Describe("Create template", func() {
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat(".npmrc")
-
-			Expect(os.IsNotExist(err)).To(BeTrue())
-		})
-
-		It("does NOT contain package.json file", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName: "test-gin-templates",
-				Variant: tests.API,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			_, err := os.Stat("package.json")
 
 			Expect(os.IsNotExist(err)).To(BeTrue())
 		})
@@ -778,19 +756,6 @@ var _ = Describe("Create template", func() {
 			content := tests.ReadFile("bootstrap/router.go")
 
 			expectedContent := "webrouter \"github.com/nimblehq/test-gin-templates/lib/web/routers\""
-
-			Expect(content).NotTo(ContainSubstring(expectedContent))
-		})
-
-		It("does NOT contain npm install in Makefile", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName: "test-gin-templates",
-				Variant: tests.API,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile("Makefile")
-
-			expectedContent := "npm install"
 
 			Expect(content).NotTo(ContainSubstring(expectedContent))
 		})
@@ -1017,9 +982,8 @@ var _ = Describe("Create template", func() {
 		Context("given only Web variant", func() {
 			It("does NOT contains openapi requirement in .eslintrc.json", func() {
 				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					Variant:    tests.Web,
-					UseOpenAPI: tests.Yes,
+					AppName: "test-gin-templates",
+					Variant: tests.Web,
 				}
 				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 				content := tests.ReadFile(".eslintrc.json")
@@ -1033,9 +997,8 @@ var _ = Describe("Create template", func() {
 		Context("given only API variant", func() {
 			It("contains openapi requirement in .eslintrc.json", func() {
 				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					Variant:    tests.API,
-					UseOpenAPI: tests.Yes,
+					AppName: "test-gin-templates",
+					Variant: tests.API,
 				}
 				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 				content := tests.ReadFile(".eslintrc.json")
@@ -1049,9 +1012,8 @@ var _ = Describe("Create template", func() {
 		Context("given both variant", func() {
 			It("contains openapi requirement in .eslintrc.json", func() {
 				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					Variant:    tests.Both,
-					UseOpenAPI: tests.Yes,
+					AppName: "test-gin-templates",
+					Variant: tests.Both,
 				}
 				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 				content := tests.ReadFile(".eslintrc.json")
@@ -1064,8 +1026,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains docs/openapi folder", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat("docs/openapi")
@@ -1075,8 +1036,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains openapi instruction in README", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile("README.md")
@@ -1088,8 +1048,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains .dockerignore file", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat(".dockerignore")
@@ -1099,8 +1058,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains .eslintignore file", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat(".eslintignore")
@@ -1110,8 +1068,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains .github/workflows/lint_docs.yml file", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat(".github/workflows/lint_docs.yml")
@@ -1121,8 +1078,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains openapi requirement in .gitignore", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile(".gitignore")
@@ -1134,8 +1090,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains .spectral.yaml file", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat(".spectral.yaml")
@@ -1145,8 +1100,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains openapi requirement in .tool-versions", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile(".tool-versions")
@@ -1158,8 +1112,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains openapi requirement in Makefile", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile("Makefile")
@@ -1171,8 +1124,7 @@ var _ = Describe("Create template", func() {
 
 		It("contains openapi requirement in package.json", func() {
 			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				AppName: "test-gin-templates",
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile("package.json")
@@ -1180,160 +1132,6 @@ var _ = Describe("Create template", func() {
 			expectedContent := `"build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml"`
 
 			Expect(content).To(ContainSubstring(expectedContent))
-		})
-	})
-
-	Context("given NO openapi add-on", func() {
-		Context("given only Web variant", func() {
-			It("does NOT contains openapi requirement in .eslintrc.json", func() {
-				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					Variant:    tests.Web,
-					UseOpenAPI: tests.No,
-				}
-				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-				content := tests.ReadFile(".eslintrc.json")
-
-				expectedContent := `plugin:yml/recommended`
-
-				Expect(content).NotTo(ContainSubstring(expectedContent))
-			})
-
-			It("does NOT contains openapi requirement in package.json", func() {
-				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					Variant:    tests.Web,
-					UseOpenAPI: tests.No,
-				}
-				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-				content := tests.ReadFile("package.json")
-
-				expectedContent := `"build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml"`
-
-				Expect(content).NotTo(ContainSubstring(expectedContent))
-			})
-		})
-
-		Context("given only API variant", func() {
-			It("does NOT contains .eslintrc.json file", func() {
-				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					Variant:    tests.API,
-					UseOpenAPI: tests.No,
-				}
-				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-				_, err := os.Stat(".eslintrc.json")
-
-				Expect(os.IsNotExist(err)).To(BeTrue())
-			})
-
-			It("does NOT contains package.json file", func() {
-				cookiecutter := tests.Cookiecutter{
-					AppName:    "test-gin-templates",
-					UseOpenAPI: tests.No,
-				}
-				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-				_, err := os.Stat("package.json")
-
-				Expect(os.IsNotExist(err)).To(BeTrue())
-			})
-		})
-
-		It("does NOT contains docs/openapi folder", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				Variant:    tests.API,
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			_, err := os.Stat("docs/openapi")
-
-			Expect(os.IsNotExist(err)).To(BeTrue())
-		})
-
-		It("does NOT contains OpenAPI instruction in README", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile("README.md")
-
-			expectedContent := "Generate API documentation"
-
-			Expect(content).NotTo(ContainSubstring(expectedContent))
-		})
-
-		It("does NOT contains .dockerignore file", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			_, err := os.Stat(".dockerignore")
-
-			Expect(os.IsNotExist(err)).To(BeTrue())
-		})
-
-		It("does NOT contains .github/workflows/lint_docs.yml file", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			_, err := os.Stat(".github/workflows/lint_docs.yml")
-
-			Expect(os.IsNotExist(err)).To(BeTrue())
-		})
-
-		It("does NOT contains openapi requirement in .gitignore", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile(".gitignore")
-
-			expectedContent := "/public/openapi.yml"
-
-			Expect(content).NotTo(ContainSubstring(expectedContent))
-		})
-
-		It("does NOT contains .spectral.yaml file", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			_, err := os.Stat(".spectral.yaml")
-
-			Expect(os.IsNotExist(err)).To(BeTrue())
-		})
-
-		It("does NOT contains openapi requirement in .tool-versions", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile(".tool-versions")
-
-			expectedContent := "nodejs 18.15.0"
-
-			Expect(content).NotTo(ContainSubstring(expectedContent))
-		})
-
-		It("does NOT contains openapi requirement in Makefile", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.No,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile("Makefile")
-
-			expectedContent := "npm run build:docs"
-
-			Expect(content).NotTo(ContainSubstring(expectedContent))
 		})
 	})
 })

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -663,19 +663,6 @@ var _ = Describe("Create template", func() {
 
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
-
-		It("contains Node 14 in README.md", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName: "test-gin-templates",
-				Variant: tests.Web,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile("README.md")
-
-			expectedContent := "[Node - 14](https://nodejs.org/en/)"
-
-			Expect(content).To(ContainSubstring(expectedContent))
-		})
 	})
 
 	Context("given NO Web variant", func() {
@@ -756,19 +743,6 @@ var _ = Describe("Create template", func() {
 			content := tests.ReadFile("bootstrap/router.go")
 
 			expectedContent := "webrouter \"github.com/nimblehq/test-gin-templates/lib/web/routers\""
-
-			Expect(content).NotTo(ContainSubstring(expectedContent))
-		})
-
-		It("does NOT contain Node 14 in README.md", func() {
-			cookiecutter := tests.Cookiecutter{
-				AppName: "test-gin-templates",
-				Variant: tests.API,
-			}
-			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
-			content := tests.ReadFile("README.md")
-
-			expectedContent := "[Node - 14](https://nodejs.org/en/)"
 
 			Expect(content).NotTo(ContainSubstring(expectedContent))
 		})

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1014,6 +1014,54 @@ var _ = Describe("Create template", func() {
 	})
 
 	Context("given openapi add-on", func() {
+		Context("given only Web variant", func() {
+			It("does NOT contains openapi requirement in .eslintrc.json", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					Variant:    tests.Web,
+					UseOpenAPI: tests.Yes,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				content := tests.ReadFile(".eslintrc.json")
+
+				expectedContent := `plugin:yml/recommended`
+
+				Expect(content).NotTo(ContainSubstring(expectedContent))
+			})
+		})
+
+		Context("given only API variant", func() {
+			It("contains openapi requirement in .eslintrc.json", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					Variant:    tests.API,
+					UseOpenAPI: tests.Yes,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				content := tests.ReadFile(".eslintrc.json")
+
+				expectedContent := `plugin:yml/recommended`
+
+				Expect(content).To(ContainSubstring(expectedContent))
+			})
+		})
+
+		Context("given both variant", func() {
+			It("contains openapi requirement in .eslintrc.json", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					Variant:    tests.Both,
+					UseOpenAPI: tests.Yes,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				content := tests.ReadFile(".eslintrc.json")
+
+				expectedContent := `plugin:yml/recommended`
+
+				Expect(content).To(ContainSubstring(expectedContent))
+			})
+		})
+
 		It("contains docs/openapi folder", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName:    "test-gin-templates",
@@ -1025,7 +1073,7 @@ var _ = Describe("Create template", func() {
 			Expect(os.IsNotExist(err)).To(BeFalse())
 		})
 
-		It("contains OpenAPI instruction in README", func() {
+		It("contains openapi instruction in README", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName:    "test-gin-templates",
 				UseOpenAPI: tests.Yes,
@@ -1037,12 +1085,164 @@ var _ = Describe("Create template", func() {
 
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
+
+		It("contains .dockerignore file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".dockerignore")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains .eslintignore file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".eslintignore")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains .github/workflows/lint_docs.yml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".github/workflows/lint_docs.yml")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains openapi requirement in .gitignore", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile(".gitignore")
+
+			expectedContent := "/public/openapi.yml"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+
+		It("contains .spectral.yaml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".spectral.yaml")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains openapi requirement in .tool-versions", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile(".tool-versions")
+
+			expectedContent := "nodejs 18.15.0"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+
+		It("contains openapi requirement in Makefile", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("Makefile")
+
+			expectedContent := "npm run build:docs"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+
+		It("contains openapi requirement in package.json", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("package.json")
+
+			expectedContent := `"build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml"`
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
 	})
 
 	Context("given NO openapi add-on", func() {
+		Context("given only Web variant", func() {
+			It("does NOT contains openapi requirement in .eslintrc.json", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					Variant:    tests.Web,
+					UseOpenAPI: tests.No,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				content := tests.ReadFile(".eslintrc.json")
+
+				expectedContent := `plugin:yml/recommended`
+
+				Expect(content).NotTo(ContainSubstring(expectedContent))
+			})
+
+			It("does NOT contains openapi requirement in package.json", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					Variant:    tests.Web,
+					UseOpenAPI: tests.No,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				content := tests.ReadFile("package.json")
+
+				expectedContent := `"build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml"`
+
+				Expect(content).NotTo(ContainSubstring(expectedContent))
+			})
+		})
+
+		Context("given only API variant", func() {
+			It("does NOT contains .eslintrc.json file", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					Variant:    tests.API,
+					UseOpenAPI: tests.No,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				_, err := os.Stat(".eslintrc.json")
+
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			})
+
+			It("does NOT contains package.json file", func() {
+				cookiecutter := tests.Cookiecutter{
+					AppName:    "test-gin-templates",
+					UseOpenAPI: tests.No,
+				}
+				cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+				_, err := os.Stat("package.json")
+
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			})
+		})
+
 		It("does NOT contains docs/openapi folder", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName:    "test-gin-templates",
+				Variant:    tests.API,
 				UseOpenAPI: tests.No,
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
@@ -1060,6 +1260,78 @@ var _ = Describe("Create template", func() {
 			content := tests.ReadFile("README.md")
 
 			expectedContent := "Generate API documentation"
+
+			Expect(content).NotTo(ContainSubstring(expectedContent))
+		})
+
+		It("does NOT contains .dockerignore file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".dockerignore")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contains .github/workflows/lint_docs.yml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".github/workflows/lint_docs.yml")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contains openapi requirement in .gitignore", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile(".gitignore")
+
+			expectedContent := "/public/openapi.yml"
+
+			Expect(content).NotTo(ContainSubstring(expectedContent))
+		})
+
+		It("does NOT contains .spectral.yaml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".spectral.yaml")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contains openapi requirement in .tool-versions", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile(".tool-versions")
+
+			expectedContent := "nodejs 18.15.0"
+
+			Expect(content).NotTo(ContainSubstring(expectedContent))
+		})
+
+		It("does NOT contains openapi requirement in Makefile", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("Makefile")
+
+			expectedContent := "npm run build:docs"
 
 			Expect(content).NotTo(ContainSubstring(expectedContent))
 		})

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1039,11 +1039,11 @@ var _ = Describe("Create template", func() {
 		})
 	})
 
-	Context("given NO heroku add-on", func() {
+	Context("given NO openapi add-on", func() {
 		It("does NOT contains docs/openapi folder", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				UseOpenAPI: tests.No,
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			_, err := os.Stat("docs/openapi")
@@ -1054,7 +1054,7 @@ var _ = Describe("Create template", func() {
 		It("does NOT contains OpenAPI instruction in README", func() {
 			cookiecutter := tests.Cookiecutter{
 				AppName:    "test-gin-templates",
-				UseOpenAPI: tests.Yes,
+				UseOpenAPI: tests.No,
 			}
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile("README.md")

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1012,4 +1012,56 @@ var _ = Describe("Create template", func() {
 			Expect(content).NotTo(ContainSubstring(expectedContent))
 		})
 	})
+
+	Context("given openapi add-on", func() {
+		It("contains docs/openapi folder", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("docs/openapi")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains OpenAPI instruction in README", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("README.md")
+
+			expectedContent := "Generate API documentation"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+	})
+
+	Context("given NO heroku add-on", func() {
+		It("does NOT contains docs/openapi folder", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("docs/openapi")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contains OpenAPI instruction in README", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:    "test-gin-templates",
+				UseOpenAPI: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("README.md")
+
+			expectedContent := "Generate API documentation"
+
+			Expect(content).NotTo(ContainSubstring(expectedContent))
+		})
+	})
 })

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,11 +4,9 @@
   "css_addon": ["Bootstrap", "Tailwind", "None"],
   "use_logrus": ["yes", "no"],
   "use_heroku": ["yes", "no"],
-  "use_openapi": ["yes", "no"],
 
   "_api_variant": "no",
   "_web_variant": "no",
-  "_both_variant": "no",
   "_bootstrap_addon": "no",
   "_tailwind_addon": "no"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
   "css_addon": ["Bootstrap", "Tailwind", "None"],
   "use_logrus": ["yes", "no"],
   "use_heroku": ["yes", "no"],
+  "use_openapi": ["yes", "no"],
 
   "_api_variant": "no",
   "_web_variant": "no",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,7 +9,6 @@
   "_api_variant": "no",
   "_web_variant": "no",
   "_both_variant": "no",
-  "_only_web_variant": "no",
   "_bootstrap_addon": "no",
   "_tailwind_addon": "no"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
 
   "_api_variant": "no",
   "_web_variant": "no",
+  "_only_web_variant": "no",
   "_bootstrap_addon": "no",
   "_tailwind_addon": "no"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
 
   "_api_variant": "no",
   "_web_variant": "no",
+  "_both_variant": "no",
   "_only_web_variant": "no",
   "_bootstrap_addon": "no",
   "_tailwind_addon": "no"

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -95,7 +95,7 @@ if '{{ cookiecutter._web_variant }}' == 'no':
     remove_file('postcss.config.js')
     remove_file('tsconfig.json')
 
-# Remove openapi if not seleted
+# Remove openapi if the project has web variant only
 if '{{ cookiecutter._api_variant }}' == 'no':
     print_log('Removing openapi')
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -111,6 +111,7 @@ if '{{ cookiecutter.use_openapi }}' == 'no':
     remove_file(".dockerignore")
     remove_file(".eslintignore")
     remove_file(".spectral.yaml")
+    remove_file(".github/workflows/lint_docs.yml")
 
 # Download the missing dependencies
 print_log('Downloading dependencies')

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -117,9 +117,6 @@ if '{{ cookiecutter.use_openapi }}' == 'no':
 print_log('Downloading dependencies')
 subprocess.call(['go', 'mod', 'tidy'])
 
-if '{{ cookiecutter._web_variant }}' == 'yes' or '{{ cookiecutter.use_openapi }}' == 'yes':
-    subprocess.call(['npm', 'install'])
-
 # Format code
 print_log('Formating code')
 subprocess.call(['go', 'fmt', './...'])

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -95,13 +95,8 @@ if '{{ cookiecutter._web_variant }}' == 'no':
     remove_file('postcss.config.js')
     remove_file('tsconfig.json')
 
-    # Remove if openapi is not selected
-    if '{{ cookiecutter.use_openapi }}' == 'no':
-        remove_file('.eslintrc.json')
-        remove_file('package.json')
-
 # Remove openapi if not seleted
-if '{{ cookiecutter.use_openapi }}' == 'no':
+if '{{ cookiecutter._api_variant }}' == 'no':
     print_log('Removing openapi')
 
     # docs folder

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -90,12 +90,27 @@ if '{{ cookiecutter._web_variant }}' == 'no':
     remove_files('lib/web')
 
     # Config files
-    remove_file('.eslintrc.json')
     remove_file('.npmrc')
-    remove_file('package.json')
     remove_file('snowpack.config.js')
     remove_file('postcss.config.js')
     remove_file('tsconfig.json')
+
+    # Remove if openapi is not selected
+    if '{{ cookiecutter.use_openapi }}' == 'no':
+        remove_file('.eslintrc.json')
+        remove_file('package.json')
+
+# Remove openapi if not seleted
+if '{{ cookiecutter.use_openapi }}' == 'no':
+    print_log('Removing openapi')
+
+    # docs folder
+    remove_files("docs")
+
+    # openapi related files
+    remove_file(".dockerignore")
+    remove_file(".eslintignore")
+    remove_file(".spectral.yaml")
 
 # Download the missing dependencies
 print_log('Downloading dependencies')

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -116,6 +116,9 @@ if '{{ cookiecutter.use_openapi }}' == 'no':
 print_log('Downloading dependencies')
 subprocess.call(['go', 'mod', 'tidy'])
 
+if '{{ cookiecutter._web_variant }}' == 'yes' or '{{ cookiecutter.use_openapi }}' == 'yes':
+    subprocess.call(['npm', 'install'])
+
 # Format code
 print_log('Formating code')
 subprocess.call(['go', 'fmt', './...'])

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -5,9 +5,14 @@ Setting easy to read/maintain cookiecutter variables:
 Web/API Variant
 cookiecutter._web_variant
 cookiecutter._api_variant
+cookiecutter._only_web_variant
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
     {{ cookiecutter.update({ '_web_variant': 'yes' }) }}
+{% endif %}
+
+{% if cookiecutter.variant == 'Web only' %}
+    {{ cookiecutter.update({ '_only_web_variant': 'yes' }) }}
 {% endif %}
 
 API Variant
@@ -27,5 +32,14 @@ Only project with web:
     {% elif cookiecutter.css_addon == 'Tailwind' %}
         {{ cookiecutter.update({ '_tailwind_addon': 'yes' }) }}
     {% endif %}
+{% endif %}
+
+-----------
+OpenAPI
+cookiecutter.use_openapi
+-----------
+Only project with web only:
+{% if cookiecutter._only_web_variant == 'yes' %}
+    {{ cookiecutter.update({ 'use_openapi': 'no' }) }}
 {% endif %}
 '''

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -6,6 +6,7 @@ Web/API Variant
 cookiecutter._web_variant
 cookiecutter._api_variant
 cookiecutter._only_web_variant
+cookiecutter._both_variant
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
     {{ cookiecutter.update({ '_web_variant': 'yes' }) }}
@@ -15,9 +16,12 @@ cookiecutter._only_web_variant
     {{ cookiecutter.update({ '_only_web_variant': 'yes' }) }}
 {% endif %}
 
-API Variant
 {% if cookiecutter.variant in ['API only', 'Both'] %}
     {{ cookiecutter.update({ '_api_variant': 'yes' }) }}
+{% endif %}
+
+{% if cookiecutter.variant == 'Both' %}
+    {{ cookiecutter.update({ '_both_variant': 'yes' }) }}
 {% endif %}
 
 -----------

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -10,6 +10,7 @@ cookiecutter._api_variant
     {{ cookiecutter.update({ '_web_variant': 'yes' }) }}
 {% endif %}
 
+API Variant
 {% if cookiecutter.variant in ['API only', 'Both'] %}
     {{ cookiecutter.update({ '_api_variant': 'yes' }) }}
 {% endif %}

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -5,7 +5,6 @@ Setting easy to read/maintain cookiecutter variables:
 Web/API Variant
 cookiecutter._web_variant
 cookiecutter._api_variant
-cookiecutter._both_variant
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
     {{ cookiecutter.update({ '_web_variant': 'yes' }) }}
@@ -13,10 +12,6 @@ cookiecutter._both_variant
 
 {% if cookiecutter.variant in ['API only', 'Both'] %}
     {{ cookiecutter.update({ '_api_variant': 'yes' }) }}
-{% endif %}
-
-{% if cookiecutter.variant == 'Both' %}
-    {{ cookiecutter.update({ '_both_variant': 'yes' }) }}
 {% endif %}
 
 -----------
@@ -31,14 +26,5 @@ Only project with web:
     {% elif cookiecutter.css_addon == 'Tailwind' %}
         {{ cookiecutter.update({ '_tailwind_addon': 'yes' }) }}
     {% endif %}
-{% endif %}
-
------------
-OpenAPI
-cookiecutter.use_openapi
------------
-Only project with web only:
-{% if cookiecutter._web_variant == 'yes' and cookiecutter._both_variant == 'no' %}
-    {{ cookiecutter.update({ 'use_openapi': 'no' }) }}
 {% endif %}
 '''

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -5,15 +5,10 @@ Setting easy to read/maintain cookiecutter variables:
 Web/API Variant
 cookiecutter._web_variant
 cookiecutter._api_variant
-cookiecutter._only_web_variant
 cookiecutter._both_variant
 -----------
 {% if cookiecutter.variant in ['Web only', 'Both'] %}
     {{ cookiecutter.update({ '_web_variant': 'yes' }) }}
-{% endif %}
-
-{% if cookiecutter.variant == 'Web only' %}
-    {{ cookiecutter.update({ '_only_web_variant': 'yes' }) }}
 {% endif %}
 
 {% if cookiecutter.variant in ['API only', 'Both'] %}
@@ -43,7 +38,7 @@ OpenAPI
 cookiecutter.use_openapi
 -----------
 Only project with web only:
-{% if cookiecutter._only_web_variant == 'yes' %}
+{% if cookiecutter._web_variant == 'yes' and cookiecutter._both_variant == 'no' %}
     {{ cookiecutter.update({ 'use_openapi': 'no' }) }}
 {% endif %}
 '''

--- a/tests/cookiecutter.go
+++ b/tests/cookiecutter.go
@@ -25,11 +25,12 @@ const (
 
 // Field and order MUST be the same as cookiecutter.json
 type Cookiecutter struct {
-	AppName   string
-	Variant   Variants
-	CssAddon  CssAddons
-	UseLogrus Choices
-	UseHeroku Choices
+	AppName    string
+	Variant    Variants
+	CssAddon   CssAddons
+	UseLogrus  Choices
+	UseHeroku  Choices
+	UseOpenAPI Choices
 }
 
 func (c *Cookiecutter) fillDefaultValue() {
@@ -43,6 +44,10 @@ func (c *Cookiecutter) fillDefaultValue() {
 
 	if c.UseHeroku != Yes && c.UseHeroku != No {
 		c.UseHeroku = No
+	}
+
+	if c.UseOpenAPI != Yes && c.UseOpenAPI != No {
+		c.UseOpenAPI = No
 	}
 
 	if c.CssAddon != Bootstrap && c.CssAddon != Tailwind && c.CssAddon != None {

--- a/tests/cookiecutter.go
+++ b/tests/cookiecutter.go
@@ -25,12 +25,11 @@ const (
 
 // Field and order MUST be the same as cookiecutter.json
 type Cookiecutter struct {
-	AppName    string
-	Variant    Variants
-	CssAddon   CssAddons
-	UseLogrus  Choices
-	UseHeroku  Choices
-	UseOpenAPI Choices
+	AppName   string
+	Variant   Variants
+	CssAddon  CssAddons
+	UseLogrus Choices
+	UseHeroku Choices
 }
 
 func (c *Cookiecutter) fillDefaultValue() {
@@ -44,10 +43,6 @@ func (c *Cookiecutter) fillDefaultValue() {
 
 	if c.UseHeroku != Yes && c.UseHeroku != No {
 		c.UseHeroku = No
-	}
-
-	if c.UseOpenAPI != Yes && c.UseOpenAPI != No {
-		c.UseOpenAPI = No
 	}
 
 	if c.CssAddon != Bootstrap && c.CssAddon != Tailwind && c.CssAddon != None {

--- a/{{cookiecutter.app_name}}/.dockerignore
+++ b/{{cookiecutter.app_name}}/.dockerignore
@@ -1,7 +1,5 @@
 .github/
 .gitignore
-{%- if cookiecutter._web_variant == "yes" or cookiecutter.use_openapi == "yes" -%}
 node_modules/
-{% endif %}
 docker-compose.dev.yml
 README.md

--- a/{{cookiecutter.app_name}}/.dockerignore
+++ b/{{cookiecutter.app_name}}/.dockerignore
@@ -1,0 +1,7 @@
+.github/
+.gitignore
+{%- if cookiecutter._web_variant == "yes" || cookiecutter.use_openapi == "yes" -%}
+node_modules/
+{% endif %}
+docker-compose.dev.yml
+README.md

--- a/{{cookiecutter.app_name}}/.dockerignore
+++ b/{{cookiecutter.app_name}}/.dockerignore
@@ -1,6 +1,6 @@
 .github/
 .gitignore
-{%- if cookiecutter._web_variant == "yes" || cookiecutter.use_openapi == "yes" -%}
+{%- if cookiecutter._web_variant == "yes" ors cookiecutter.use_openapi == "yes" -%}
 node_modules/
 {% endif %}
 docker-compose.dev.yml

--- a/{{cookiecutter.app_name}}/.dockerignore
+++ b/{{cookiecutter.app_name}}/.dockerignore
@@ -1,6 +1,6 @@
 .github/
 .gitignore
-{%- if cookiecutter._web_variant == "yes" ors cookiecutter.use_openapi == "yes" -%}
+{%- if cookiecutter._web_variant == "yes" or cookiecutter.use_openapi == "yes" -%}
 node_modules/
 {% endif %}
 docker-compose.dev.yml

--- a/{{cookiecutter.app_name}}/.eslintignore
+++ b/{{cookiecutter.app_name}}/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules/**
+/public/**

--- a/{{cookiecutter.app_name}}/.eslintrc.json
+++ b/{{cookiecutter.app_name}}/.eslintrc.json
@@ -19,7 +19,7 @@
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"
   }
-}{% endif %}{% if cookiecutter._api_variant == "yes" and cookiecutter.use_openapi == "yes" %}{
+}{% endif %}{% if cookiecutter._both_variant == "no" and cookiecutter.use_openapi == "yes" %}{
   "extends": [
     "@nimblehq/eslint-config-nimble",
     "plugin:yml/recommended"

--- a/{{cookiecutter.app_name}}/.eslintrc.json
+++ b/{{cookiecutter.app_name}}/.eslintrc.json
@@ -11,7 +11,9 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended"{% if cookiecutter.use_openapi == "yes" %},
+    "@nimblehq/eslint-config-nimble",
+    "plugin:yml/recommended"{% endif %}
   ],
   "globals": {
     "Atomics": "readonly",
@@ -21,8 +23,5 @@
   "extends": [
     "@nimblehq/eslint-config-nimble",
     "plugin:yml/recommended"
-  ],
-  "globals": {
-    "I18n": true
-  }
+  ]
 }{% endif %}

--- a/{{cookiecutter.app_name}}/.eslintrc.json
+++ b/{{cookiecutter.app_name}}/.eslintrc.json
@@ -19,7 +19,7 @@
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"
   }
-}{% endif %}{% if cookiecutter.use_openapi == "yes" %}{
+}{% endif %}{% if cookiecutter._api_variant == "yes" and cookiecutter.use_openapi == "yes" %}{
   "extends": [
     "@nimblehq/eslint-config-nimble",
     "plugin:yml/recommended"

--- a/{{cookiecutter.app_name}}/.eslintrc.json
+++ b/{{cookiecutter.app_name}}/.eslintrc.json
@@ -1,5 +1,4 @@
-{% if cookiecutter._web_variant == "yes" %}
-{
+{% if cookiecutter._web_variant == "yes" %}{
   "rules": {},
   "env": {
     "es6": true,
@@ -18,10 +17,7 @@
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"
   }
-}
-{% endif %}
-{% if cookiecutter.use_openapi == "yes" %}
-{
+}{% endif %}{% if cookiecutter.use_openapi == "yes" %}{
   "extends": [
     "@nimblehq/eslint-config-nimble",
     "plugin:yml/recommended"
@@ -29,5 +25,4 @@
   "globals": {
     "I18n": true
   }
-}
-{% endif %}
+}{% endif %}

--- a/{{cookiecutter.app_name}}/.eslintrc.json
+++ b/{{cookiecutter.app_name}}/.eslintrc.json
@@ -11,7 +11,7 @@
   },
   "extends": [
     "eslint:recommended",
-    "plugin:prettier/recommended"{% if cookiecutter.use_openapi == "yes" %},
+    "plugin:prettier/recommended"{% if cookiecutter._api_variant == "yes" %},
     "@nimblehq/eslint-config-nimble",
     "plugin:yml/recommended"{% endif %}
   ],
@@ -19,7 +19,7 @@
     "Atomics": "readonly",
     "SharedArrayBuffer": "readonly"
   }
-}{% endif %}{% if cookiecutter._both_variant == "no" and cookiecutter.use_openapi == "yes" %}{
+}{% endif %}{% if cookiecutter._api_variant == "yes" and cookiecutter._web_variant == "no" %}{
   "extends": [
     "@nimblehq/eslint-config-nimble",
     "plugin:yml/recommended"

--- a/{{cookiecutter.app_name}}/.eslintrc.json
+++ b/{{cookiecutter.app_name}}/.eslintrc.json
@@ -1,3 +1,4 @@
+{% if cookiecutter._web_variant == "yes" %}
 {
   "rules": {},
   "env": {
@@ -18,3 +19,15 @@
     "SharedArrayBuffer": "readonly"
   }
 }
+{% endif %}
+{% if cookiecutter.use_openapi == "yes" %}
+{
+  "extends": [
+    "@nimblehq/eslint-config-nimble",
+    "plugin:yml/recommended"
+  ],
+  "globals": {
+    "I18n": true
+  }
+}
+{% endif %}

--- a/{{cookiecutter.app_name}}/.github/workflows/lint_docs.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/lint_docs.yml
@@ -1,0 +1,31 @@
+name: Lint OpenAPI docs
+
+on: pull_request
+
+concurrency:
+  group: {{ "${{ github.workflow }}-${{ github.ref }}" }}
+  cancel-in-progress: true
+
+jobs:
+  docs_lint:
+    name: Run lint for API docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up node and restore cached dependencies
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Generate API docs
+        run: npm run build:docs
+
+      - name: Run API docs linters
+        run: npm run lint:docs:public

--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -1,5 +1,4 @@
-{%- if cookiecutter._web_variant == "yes" or cookiecutter.use_openapi == "yes" %}
-/node_modules
+{%- if cookiecutter._web_variant == "yes" or cookiecutter.use_openapi == "yes" %}/node_modules
 {%- endif %}
 tmp/
 coverage/

--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -11,7 +11,7 @@ deploy/**/terraform.tfstate.backup
 deploy/**/*.tfvars
 {%- endif %}
 
-{% if cookiecutter.use_openapi == "yes" %}
+{%- if cookiecutter.use_openapi == "yes" %}
 ## OpenAPI
 /public/openapi.yml
-{% endif %}
+{%- endif %}

--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -1,5 +1,7 @@
-{% if cookiecutter._web_variant == "yes" %}/node_modules
-{% endif %}tmp/
+{%- if cookiecutter._web_variant == "yes" or cookiecutter.use_openapi == "yes" %}
+/node_modules
+{%- endif %}
+tmp/
 coverage/
 .env
 

--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -10,3 +10,8 @@ deploy/**/terraform.tfstate
 deploy/**/terraform.tfstate.backup
 deploy/**/*.tfvars
 {%- endif %}
+
+{% if cookiecutter.use_openapi == "yes" %}
+## OpenAPI
+/public/openapi.yml
+{% endif %}

--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -1,5 +1,4 @@
-{%- if cookiecutter._web_variant == "yes" or cookiecutter.use_openapi == "yes" %}/node_modules
-{%- endif %}
+/node_modules
 tmp/
 coverage/
 .env
@@ -12,7 +11,7 @@ deploy/**/terraform.tfstate.backup
 deploy/**/*.tfvars
 {%- endif %}
 
-{%- if cookiecutter.use_openapi == "yes" %}
+{%- if cookiecutter._api_variant == "yes" %}
 ## OpenAPI
 /public/openapi.yml
 {%- endif %}

--- a/{{cookiecutter.app_name}}/.spectral.yaml
+++ b/{{cookiecutter.app_name}}/.spectral.yaml
@@ -1,0 +1,6 @@
+extends: ["spectral:oas"]
+
+rules:
+  oas3-unused-component: false
+  operation-operationId: false
+  info-contact: false

--- a/{{cookiecutter.app_name}}/.tool-versions
+++ b/{{cookiecutter.app_name}}/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.20{% if cookiecutter.use_openapi == "yes" %}
-nodejs 18.15.0{% endif %}
+golang 1.20
+nodejs 18.15.0

--- a/{{cookiecutter.app_name}}/.tool-versions
+++ b/{{cookiecutter.app_name}}/.tool-versions
@@ -1,1 +1,4 @@
 golang 1.20
+{% if cookiecutter.use_openapi == "yes" %}
+nodejs 18.15.0
+{% endif %}

--- a/{{cookiecutter.app_name}}/.tool-versions
+++ b/{{cookiecutter.app_name}}/.tool-versions
@@ -1,4 +1,2 @@
-golang 1.20
-{% if cookiecutter.use_openapi == "yes" %}
-nodejs 18.15.0
-{% endif %}
+golang 1.20{% if cookiecutter.use_openapi == "yes" %}
+nodejs 18.15.0{% endif %}

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -28,8 +28,7 @@ endif
 migration/status:
 	goose -dir database/migrations -table "migration_versions" postgres "$(DATABASE_URL)" status
 
-{%- if cookiecutter.use_openapi == "yes" %}
-doc/generate:
+{% if cookiecutter.use_openapi == "yes" %}doc/generate:
 	npm run build:docs
 {%- endif %}
 

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -28,8 +28,10 @@ endif
 migration/status:
 	goose -dir database/migrations -table "migration_versions" postgres "$(DATABASE_URL)" status
 
-{% if cookiecutter.use_openapi == "yes" %}doc/generate:
-	npm run build:docs{% endif %}
+{%- if cookiecutter.use_openapi == "yes" %}
+doc/generate:
+	npm run build:docs
+{%- endif %}
 
 dev:
 	make env-setup
@@ -41,8 +43,8 @@ install-dependencies:
 	go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 	go install github.com/ddollar/forego@latest
 	go mod tidy
-	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
-	{% if cookiecutter.use_openapi == "yes" %}make doc/generate{% endif %}
+	{%- if cookiecutter._web_variant == "yes" %}npm install{% endif %}
+	{%- if cookiecutter.use_openapi == "yes" %}make doc/generate{% endif %}
 
 test:
 	docker compose -f docker-compose.test.yml up -d

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -42,8 +42,8 @@ install-dependencies:
 	go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 	go install github.com/ddollar/forego@latest
 	go mod tidy
-	{%- if cookiecutter._web_variant == "yes" %}npm install{% endif %}
-	{%- if cookiecutter.use_openapi == "yes" %}make doc/generate{% endif %}
+	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
+	{% if cookiecutter.use_openapi == "yes" %}make doc/generate{%- endif %}
 
 test:
 	docker compose -f docker-compose.test.yml up -d

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -28,6 +28,11 @@ endif
 migration/status:
 	goose -dir database/migrations -table "migration_versions" postgres "$(DATABASE_URL)" status
 
+{% if cookiecutter.use_openapi == "yes" %}
+doc/generate:
+	npm run build:docs
+{% endif %}
+
 dev:
 	make env-setup
 	make db/migrate
@@ -39,6 +44,7 @@ install-dependencies:
 	go install github.com/ddollar/forego@latest
 	go mod tidy
 	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
+	{% if cookiecutter.use_openapi == "yes" %}make doc/generate{% endif %}
 
 test:
 	docker compose -f docker-compose.test.yml up -d

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -28,10 +28,8 @@ endif
 migration/status:
 	goose -dir database/migrations -table "migration_versions" postgres "$(DATABASE_URL)" status
 
-{% if cookiecutter.use_openapi == "yes" %}
-doc/generate:
-	npm run build:docs
-{% endif %}
+{% if cookiecutter.use_openapi == "yes" %}doc/generate:
+	npm run build:docs{% endif %}
 
 dev:
 	make env-setup

--- a/{{cookiecutter.app_name}}/Makefile
+++ b/{{cookiecutter.app_name}}/Makefile
@@ -28,7 +28,7 @@ endif
 migration/status:
 	goose -dir database/migrations -table "migration_versions" postgres "$(DATABASE_URL)" status
 
-{% if cookiecutter.use_openapi == "yes" %}doc/generate:
+{% if cookiecutter._api_variant == "yes" %}doc/generate:
 	npm run build:docs
 {%- endif %}
 
@@ -42,8 +42,8 @@ install-dependencies:
 	go install github.com/pressly/goose/v3/cmd/goose@v3.9.0
 	go install github.com/ddollar/forego@latest
 	go mod tidy
-	{% if cookiecutter._web_variant == "yes" %}npm install{% endif %}
-	{% if cookiecutter.use_openapi == "yes" %}make doc/generate{%- endif %}
+	npm install
+	{% if cookiecutter._api_variant == "yes" %}make doc/generate{%- endif %}
 
 test:
 	docker compose -f docker-compose.test.yml up -d

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -9,6 +9,7 @@
 ### Prerequisites
 
 - [Go - 1.20](https://golang.org/doc/go1.20) or newer
+- [Node - 18](https://nodejs.org/en/)
 
 {% if cookiecutter._web_variant == "yes" %}- [Node - 14](https://nodejs.org/en/){% endif %}
 

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -11,8 +11,6 @@
 - [Go - 1.20](https://golang.org/doc/go1.20) or newer
 - [Node - 18](https://nodejs.org/en/)
 
-{% if cookiecutter._web_variant == "yes" %}- [Node - 14](https://nodejs.org/en/){% endif %}
-
 ### Development
 
 #### Create an ENV file

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -50,6 +50,15 @@ Execute all unit tests:
 ```make
 make test
 ```
+{%- if cookiecutter.use_openapi == "yes" %}
+### API Documentation
+
+Generate API documentation:
+
+```make
+make doc/generate
+```
+{%- endif %}
 
 ### Migration
 

--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -50,7 +50,7 @@ Execute all unit tests:
 ```make
 make test
 ```
-{%- if cookiecutter.use_openapi == "yes" %}
+{%- if cookiecutter._api_variant == "yes" %}
 ### API Documentation
 
 Generate API documentation:

--- a/{{cookiecutter.app_name}}/docs/openapi/examples/responses/health.json
+++ b/{{cookiecutter.app_name}}/docs/openapi/examples/responses/health.json
@@ -1,0 +1,24 @@
+{
+    "ok": {
+        "value": {
+            "data": {
+                "id": "1",
+                "type": "health",
+                "attributes": {
+                    "message": "OK"
+                }
+            }
+        }
+    },
+    "error": {
+        "value": {
+            "errors": [
+                {
+                    "status": "500",
+                    "title": "Internal Server Error",
+                    "detail": "Something went wrong."
+                }
+            ]
+        }
+    }
+}

--- a/{{cookiecutter.app_name}}/docs/openapi/openapi.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/openapi.yml
@@ -6,8 +6,8 @@ info:
   version: 1.0.0
 
 servers:
-  - url: http://localhost:4010
-    description: Mock server
+  - url: http://localhost:8080/api/v1
+    description: Development Base URL
 
 security:
   - BearerAuth: []

--- a/{{cookiecutter.app_name}}/docs/openapi/openapi.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/openapi.yml
@@ -1,0 +1,31 @@
+---
+openapi: 3.0.0
+info:
+  title: API Documentation
+  description: This is the API documentation for the mock server.
+  version: 1.0.0
+
+servers:
+  - url: http://localhost:4010
+    description: Mock server
+
+security:
+  - BearerAuth: []
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+  schemas:
+    $ref: "schemas.yml"
+  responses:
+    $ref: "responses.yml"
+
+paths:
+  /health:
+    $ref: "paths/health.yml"
+
+tags:
+  - name: Status
+    description: Status APIs of the project

--- a/{{cookiecutter.app_name}}/docs/openapi/paths/health.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/paths/health.yml
@@ -1,0 +1,20 @@
+---
+get:
+  tags:
+    - Status
+  security: []
+  summary: Get the status of the application.
+  description: Call this API to get the status of the application.
+
+  responses:
+    '200':
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas.yml#/responses_health'
+          examples:
+            $ref: '../examples/responses/health.json'
+
+    default:
+      $ref: '../responses.yml#/responses_default_error'

--- a/{{cookiecutter.app_name}}/docs/openapi/responses.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/responses.yml
@@ -1,0 +1,4 @@
+---
+
+responses_default_error:
+  $ref: "responses/default_error.yml"

--- a/{{cookiecutter.app_name}}/docs/openapi/responses/default_error.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/responses/default_error.yml
@@ -1,0 +1,11 @@
+---
+description: Default Error
+
+content:
+  application/json:
+    schema:
+      $ref: '../schemas.yml#/error'
+    example:
+      errors:
+        - code: 'invalid_request'
+          detail: 'The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed.'

--- a/{{cookiecutter.app_name}}/docs/openapi/schemas.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/schemas.yml
@@ -1,0 +1,12 @@
+---
+#### REQUESTS ####
+
+#### RESPONSES ####
+
+responses_health:
+  $ref: "schemas/responses/health.yml"
+
+#### REUSABLE SCHEMAS ####
+
+error:
+  $ref: "schemas/shared/error.yml"

--- a/{{cookiecutter.app_name}}/docs/openapi/schemas/responses/health.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/schemas/responses/health.yml
@@ -1,0 +1,24 @@
+---
+type: object
+
+description: A response body for the health API
+
+properties:
+  data:
+    type: object
+    description: The data object
+    properties:
+      id:
+        type: string
+        description: The identifier of the health
+        example: "123"
+      type:
+        type: string
+        description: The type of the health
+        example: 'health'
+      attributes:
+        type: object
+        properties:
+          message:
+            type: string
+            description: The message description of the status

--- a/{{cookiecutter.app_name}}/docs/openapi/schemas/shared/error.yml
+++ b/{{cookiecutter.app_name}}/docs/openapi/schemas/shared/error.yml
@@ -1,0 +1,15 @@
+type: object
+
+properties:
+  errors:
+    type: array
+    maxItems: 10
+    items:
+      type: object
+      properties:
+        code:
+          type: string
+          description: an application-specific error code
+        detail:
+          type: string
+          description: "a human-readable explanation specific to this occurrence of the problem. Like title, this field's value can be localized."

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -6,16 +6,28 @@
   "author": "NimbleHQ",
   "license": "MIT",
   "scripts": {
+    {% if cookiecutter._web_variant == "yes" %}
     "dev": "NODE_ENV=development MODE=development snowpack build --watch --no-minify --no-bundle",
     "build": "snowpack build",
-    "clean": "rm -rf static"
+    "clean": "rm -rf static",
+    {% endif %}
+    {% if cookiecutter.use_openapi == "yes" %}
+    "lint:docs:yml": "eslint docs/openapi --ext .yml --color",
+    "lint:docs:openapi": "spectral lint docs/openapi/openapi.yml -F error",
+    "lint:docs:dev": "yarn lint:docs:yml && yarn lint:docs:openapi",
+    "lint:docs:public": "yarn build:docs && eslint public/openapi.yml --color --no-ignore && spectral lint public/openapi.yml -F error",
+    "build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml",
+    {% endif %}
   },
   "devDependencies": {
+    {% if cookiecutter._web_variant == "yes" %}
     "@snowpack/plugin-postcss": "1.4.3",
     "@snowpack/plugin-sass": "1.4.0",
     "@types/node": "15.12.5",
-    "autoprefixer": "10.2.6",{% if cookiecutter._bootstrap_addon == "yes" %}
-    "bootstrap": "5.0.2",{% endif %}
+    "autoprefixer": "10.2.6",
+    {% if cookiecutter._bootstrap_addon == "yes" %}
+    "bootstrap": "5.0.2",
+    {% endif %}
     "eslint": "7.29.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",
@@ -23,5 +35,12 @@
     "prettier": "2.3.2",
     "snowpack": "3.7.1"{% if cookiecutter._tailwind_addon == "yes" %},
     "tailwindcss": "2.2.7"{% endif %}
+    {% endif %}
+    {% if cookiecutter.use_openapi == "yes" %}
+    "@apidevtools/swagger-cli": "4.0.4",
+    "@nimblehq/eslint-config-nimble": "2.1.1",
+    "@stoplight/spectral-cli": "6.8.0",
+    "eslint-plugin-yml": "1.8.0"
+    {% endif %}
   }
 }

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -9,9 +9,9 @@
     {%- if cookiecutter._web_variant == "yes" %}
     "dev": "NODE_ENV=development MODE=development snowpack build --watch --no-minify --no-bundle",
     "build": "snowpack build",
-    "clean": "rm -rf static"{%- if cookiecutter.use_openapi == "yes" %},{%- endif %}
+    "clean": "rm -rf static"{%- if cookiecutter._api_variant == "yes" %},{%- endif %}
     {%- endif %}
-    {%- if cookiecutter.use_openapi == "yes" %}
+    {%- if cookiecutter._api_variant == "yes" %}
     "lint:docs:yml": "eslint docs/openapi --ext .yml --color",
     "lint:docs:openapi": "spectral lint docs/openapi/openapi.yml -F error",
     "lint:docs:dev": "npm lint:docs:yml && npm lint:docs:openapi",
@@ -32,9 +32,9 @@
     "postcss": "8.3.5",
     "prettier": "2.3.2",
     "snowpack": "3.7.1"{% if cookiecutter._tailwind_addon == "yes" %},
-    "tailwindcss": "2.2.7"{% endif %}{%- if cookiecutter.use_openapi == "yes" %},{%- endif %}
+    "tailwindcss": "2.2.7"{% endif %}{%- if cookiecutter._api_variant == "yes" %},{%- endif %}
     {%- endif %}
-    {%- if cookiecutter.use_openapi == "yes" %}
+    {%- if cookiecutter._api_variant == "yes" %}
     "@apidevtools/swagger-cli": "4.0.4",
     "@nimblehq/eslint-config-nimble": "2.1.1",
     "@stoplight/spectral-cli": "6.8.0",

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -6,28 +6,26 @@
   "author": "NimbleHQ",
   "license": "MIT",
   "scripts": {
-    {% if cookiecutter._web_variant == "yes" %}
+    {%- if cookiecutter._web_variant == "yes" %}
     "dev": "NODE_ENV=development MODE=development snowpack build --watch --no-minify --no-bundle",
     "build": "snowpack build",
     "clean": "rm -rf static",
-    {% endif %}
-    {% if cookiecutter.use_openapi == "yes" %}
+    {%- endif %}
+    {%- if cookiecutter.use_openapi == "yes" %}
     "lint:docs:yml": "eslint docs/openapi --ext .yml --color",
     "lint:docs:openapi": "spectral lint docs/openapi/openapi.yml -F error",
     "lint:docs:dev": "yarn lint:docs:yml && yarn lint:docs:openapi",
     "lint:docs:public": "yarn build:docs && eslint public/openapi.yml --color --no-ignore && spectral lint public/openapi.yml -F error",
-    "build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml",
-    {% endif %}
+    "build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml"
+    {%- endif %}
   },
   "devDependencies": {
-    {% if cookiecutter._web_variant == "yes" %}
+    {%- if cookiecutter._web_variant == "yes" %}
     "@snowpack/plugin-postcss": "1.4.3",
     "@snowpack/plugin-sass": "1.4.0",
     "@types/node": "15.12.5",
-    "autoprefixer": "10.2.6",
-    {% if cookiecutter._bootstrap_addon == "yes" %}
-    "bootstrap": "5.0.2",
-    {% endif %}
+    "autoprefixer": "10.2.6",{% if cookiecutter._bootstrap_addon == "yes" %}
+    "bootstrap": "5.0.2",{% endif %}
     "eslint": "7.29.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-prettier": "3.4.0",
@@ -35,12 +33,12 @@
     "prettier": "2.3.2",
     "snowpack": "3.7.1"{% if cookiecutter._tailwind_addon == "yes" %},
     "tailwindcss": "2.2.7"{% endif %}
-    {% endif %}
-    {% if cookiecutter.use_openapi == "yes" %}
+    {%- endif %}
+    {%- if cookiecutter.use_openapi == "yes" %}
     "@apidevtools/swagger-cli": "4.0.4",
     "@nimblehq/eslint-config-nimble": "2.1.1",
     "@stoplight/spectral-cli": "6.8.0",
     "eslint-plugin-yml": "1.8.0"
-    {% endif %}
+    {%- endif %}
   }
 }

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -9,7 +9,7 @@
     {%- if cookiecutter._web_variant == "yes" %}
     "dev": "NODE_ENV=development MODE=development snowpack build --watch --no-minify --no-bundle",
     "build": "snowpack build",
-    "clean": "rm -rf static",
+    "clean": "rm -rf static"{%- if cookiecutter.use_openapi == "yes" %},{%- endif %}
     {%- endif %}
     {%- if cookiecutter.use_openapi == "yes" %}
     "lint:docs:yml": "eslint docs/openapi --ext .yml --color",

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -32,7 +32,7 @@
     "postcss": "8.3.5",
     "prettier": "2.3.2",
     "snowpack": "3.7.1"{% if cookiecutter._tailwind_addon == "yes" %},
-    "tailwindcss": "2.2.7"{% endif %}
+    "tailwindcss": "2.2.7"{% endif %}{%- if cookiecutter.use_openapi == "yes" %},{%- endif %}
     {%- endif %}
     {%- if cookiecutter.use_openapi == "yes" %}
     "@apidevtools/swagger-cli": "4.0.4",

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -14,8 +14,8 @@
     {%- if cookiecutter.use_openapi == "yes" %}
     "lint:docs:yml": "eslint docs/openapi --ext .yml --color",
     "lint:docs:openapi": "spectral lint docs/openapi/openapi.yml -F error",
-    "lint:docs:dev": "yarn lint:docs:yml && yarn lint:docs:openapi",
-    "lint:docs:public": "yarn build:docs && eslint public/openapi.yml --color --no-ignore && spectral lint public/openapi.yml -F error",
+    "lint:docs:dev": "npm lint:docs:yml && npm lint:docs:openapi",
+    "lint:docs:public": "npm build:docs && eslint public/openapi.yml --color --no-ignore && spectral lint public/openapi.yml -F error",
     "build:docs": "swagger-cli bundle docs/openapi/openapi.yml --outfile public/openapi.yml --type yaml"
     {%- endif %}
   },


### PR DESCRIPTION
#105 

## What happened 👀

- Added OpenAPI add-on.
- Added an example for OpenAPI spec (`/health` API) - in the folder `docs/openapi`.
- Added tools for OpenAPI (e.g., spectral, eslint)
- Added tests to cover cases for OpenAPI add-on.
- Added lint - CI workflow for running lint on OpenAPI spec.

## Insight 📝

This is `Part 1` for the #105 issue. I configured all needed tools to add OpenAPI into the gin templates. Here is the checklist of #105 when this pull request is merged:

- [x] Add OpenAPI addon as an optional addon in the template.
- [x] Add OpenAPI tooling (Spectral, Elements, Lint).
- [ ] Create an endpoint (e.g., GET {{base_url}}/api/docs/openapi) to access the API documentation through the browser.
- [ ] Add Mock Server with Prims (related to this [API Mock Server with OpenAPI](https://www.notion.so/API-Mock-Server-with-OpenAPI-83fda1653eb1409fab9b08c1fcf466fd?pvs=21)).
- [ ] Add CI/CD workflow to run linting and deploy mock server to fly.io:
  - [x] Linting
  -	[ ] Deploy Mock Server

## Proof Of Work 📹

Script from this branch:
![Screenshot 2023-08-14 at 11 36 54](https://github.com/nimblehq/gin-templates/assets/19943832/5df8b4ec-0e61-4656-9d54-5fd4cbc1b6b4)

Generated Project:
![Screenshot 2023-08-14 at 11 37 39](https://github.com/nimblehq/gin-templates/assets/19943832/afddb2a8-9eba-40ba-b388-803371c09a42)
