### PR TITLE
[#105] [Part 2] Add OpenAPI to support creating API documentation with OpenAPI

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1107,5 +1107,39 @@ var _ = Describe("Create template", func() {
 
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
+
+		It("contains lib/api/docs folder", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName: "test-gin-templates",
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("lib/api/docs")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains openapi requirement in go.mod", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName: "test-gin-templates",
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("go.mod")
+
+			expectedContent := "github.com/gin-gonic/contrib"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
+
+		It("contains openapi requirement in router.go", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName: "test-gin-templates",
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			content := tests.ReadFile("bootstrap/router.go")
+
+			expectedContent := "apidocsrouter.ComebineRoutes(r)"
+
+			Expect(content).To(ContainSubstring(expectedContent))
+		})
 	})
 })

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1137,7 +1137,7 @@ var _ = Describe("Create template", func() {
 			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
 			content := tests.ReadFile("bootstrap/router.go")
 
-			expectedContent := "apidocsrouter.ComebineRoutes(r)"
+			expectedContent := "apidocsrouter.CombineRoutes(r)"
 
 			Expect(content).To(ContainSubstring(expectedContent))
 		})

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -101,6 +101,7 @@ if '{{ cookiecutter._api_variant }}' == 'no':
 
     # docs folder
     remove_files("docs")
+    remove_files("lib/api/docs")
 
     # openapi related files
     remove_file(".dockerignore")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -101,7 +101,7 @@ if '{{ cookiecutter._api_variant }}' == 'no':
 
     # docs folder
     remove_files("docs")
-    remove_files("lib/api/docs")
+    remove_files("lib/api")
 
     # openapi related files
     remove_file(".dockerignore")

--- a/{{cookiecutter.app_name}}/bootstrap/router.go
+++ b/{{cookiecutter.app_name}}/bootstrap/router.go
@@ -15,9 +15,9 @@ func SetupRouter() *gin.Engine {
 
 	{% if cookiecutter._api_variant == "yes" -%}r.Use(static.Serve("/", static.LocalFile("./public", true))){%- endif %}
 
-	apiv1router.ComebineRoutes(r)
-	{% if cookiecutter._api_variant == "yes" -%}apidocsrouter.ComebineRoutes(r){%- endif %}
-	{% if cookiecutter._web_variant == "yes" %}webrouter.ComebineRoutes(r)
+	apiv1router.CombineRoutes(r)
+	{% if cookiecutter._api_variant == "yes" -%}apidocsrouter.CombineRoutes(r){%- endif %}
+	{% if cookiecutter._web_variant == "yes" %}webrouter.CombineRoutes(r)
 	{% endif %}
 	return r
 }

--- a/{{cookiecutter.app_name}}/bootstrap/router.go
+++ b/{{cookiecutter.app_name}}/bootstrap/router.go
@@ -13,8 +13,10 @@ import (
 func SetupRouter() *gin.Engine {
 	r := gin.Default()
 
+	{% if cookiecutter.use_openapi == "yes" -%}r.Use(static.Serve("/", static.LocalFile("./public", true))){%- endif %}
+
 	apiv1router.ComebineRoutes(r)
-	{% if cookiecutter.use_openapi == "yes" -%}webrouter.ComebineRoutes(r){%- endif %}
+	{% if cookiecutter.use_openapi == "yes" -%}apidocsrouter.ComebineRoutes(r){%- endif %}
 	{% if cookiecutter._web_variant == "yes" %}webrouter.ComebineRoutes(r)
 	{% endif %}
 	return r

--- a/{{cookiecutter.app_name}}/bootstrap/router.go
+++ b/{{cookiecutter.app_name}}/bootstrap/router.go
@@ -1,22 +1,22 @@
 package bootstrap
 
 import (
-	{%- if cookiecutter.use_openapi == "yes" -%}apidocsrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/docs/routers"{%- endif %}
+	{%- if cookiecutter._api_variant == "yes" -%}apidocsrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/docs/routers"{%- endif %}
 	apiv1router "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/v1/routers"
 	{% if cookiecutter._web_variant == "yes" %}webrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/web/routers"
 	{% endif %}
 
-	{%- if cookiecutter.use_openapi == "yes" -%}"github.com/gin-gonic/contrib/static"{%- endif %}
+	{%- if cookiecutter._api_variant == "yes" -%}"github.com/gin-gonic/contrib/static"{%- endif %}
 	"github.com/gin-gonic/gin"
 )
 
 func SetupRouter() *gin.Engine {
 	r := gin.Default()
 
-	{% if cookiecutter.use_openapi == "yes" -%}r.Use(static.Serve("/", static.LocalFile("./public", true))){%- endif %}
+	{% if cookiecutter._api_variant == "yes" -%}r.Use(static.Serve("/", static.LocalFile("./public", true))){%- endif %}
 
 	apiv1router.ComebineRoutes(r)
-	{% if cookiecutter.use_openapi == "yes" -%}apidocsrouter.ComebineRoutes(r){%- endif %}
+	{% if cookiecutter._api_variant == "yes" -%}apidocsrouter.ComebineRoutes(r){%- endif %}
 	{% if cookiecutter._web_variant == "yes" %}webrouter.ComebineRoutes(r)
 	{% endif %}
 	return r

--- a/{{cookiecutter.app_name}}/bootstrap/router.go
+++ b/{{cookiecutter.app_name}}/bootstrap/router.go
@@ -1,9 +1,12 @@
 package bootstrap
 
 import (
+	{%- if cookiecutter.use_openapi == "yes" -%}apidocsrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/docs/routers"{%- endif %}
 	apiv1router "github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/v1/routers"
 	{% if cookiecutter._web_variant == "yes" %}webrouter "github.com/nimblehq/{{cookiecutter.app_name}}/lib/web/routers"
 	{% endif %}
+
+	{%- if cookiecutter.use_openapi == "yes" -%}"github.com/gin-gonic/contrib/static"{%- endif %}
 	"github.com/gin-gonic/gin"
 )
 
@@ -11,6 +14,7 @@ func SetupRouter() *gin.Engine {
 	r := gin.Default()
 
 	apiv1router.ComebineRoutes(r)
+	{% if cookiecutter.use_openapi == "yes" -%}webrouter.ComebineRoutes(r){%- endif %}
 	{% if cookiecutter._web_variant == "yes" %}webrouter.ComebineRoutes(r)
 	{% endif %}
 	return r

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,4 +11,5 @@ require (
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/gorm v1.20.12
 	{% if cookiecutter.use_logrus == "yes" -%}github.com/sirupsen/logrus v1.8.1{%- endif %}
+	{% if cookiecutter.use_openapi == "yes" -%}github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2{%- endif %}
 )

--- a/{{cookiecutter.app_name}}/go.mod
+++ b/{{cookiecutter.app_name}}/go.mod
@@ -11,5 +11,5 @@ require (
 	gorm.io/driver/postgres v1.0.8
 	gorm.io/gorm v1.20.12
 	{% if cookiecutter.use_logrus == "yes" -%}github.com/sirupsen/logrus v1.8.1{%- endif %}
-	{% if cookiecutter.use_openapi == "yes" -%}github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2{%- endif %}
+	{% if cookiecutter._api_variant == "yes" -%}github.com/gin-gonic/contrib v0.0.0-20221130124618-7e01895a63f2{%- endif %}
 )

--- a/{{cookiecutter.app_name}}/lib/api/docs/controllers/openapi.go
+++ b/{{cookiecutter.app_name}}/lib/api/docs/controllers/openapi.go
@@ -1,0 +1,13 @@
+package controllers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type OpenAPIController struct{}
+
+func (OpenAPIController) Show(c *gin.Context) {
+	c.HTML(http.StatusOK, "show.html", gin.H{})
+}

--- a/{{cookiecutter.app_name}}/lib/api/docs/routers/router.go
+++ b/{{cookiecutter.app_name}}/lib/api/docs/routers/router.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ComebineRoutes(engine *gin.Engine) {
+func CombineRoutes(engine *gin.Engine) {
 	docs := engine.Group("/api/docs")
 
 	engine.LoadHTMLFiles("lib/api/docs/views/openapi/show.html")

--- a/{{cookiecutter.app_name}}/lib/api/docs/routers/router.go
+++ b/{{cookiecutter.app_name}}/lib/api/docs/routers/router.go
@@ -1,0 +1,14 @@
+package routers
+
+import (
+	"github.com/nimblehq/{{cookiecutter.app_name}}/lib/api/docs/controllers"
+
+	"github.com/gin-gonic/gin"
+)
+
+func ComebineRoutes(engine *gin.Engine) {
+	docs := engine.Group("/api/docs")
+
+	engine.LoadHTMLFiles("lib/api/docs/views/openapi/show.html")
+	docs.GET("/openapi", controllers.OpenAPIController{}.Show)
+}

--- a/{{cookiecutter.app_name}}/lib/api/docs/views/openapi/show.html
+++ b/{{cookiecutter.app_name}}/lib/api/docs/views/openapi/show.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>API documentation</title>
-  <!-- Embed elements Elements via Web Component -->
+  <!-- Embed Elements via Web Component -->
   <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
 </head>

--- a/{{cookiecutter.app_name}}/lib/api/docs/views/openapi/show.html
+++ b/{{cookiecutter.app_name}}/lib/api/docs/views/openapi/show.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <title>Open API documentation</title>
+  <!-- Embed elements Elements via Web Component -->
+  <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
+</head>
+
+<body>
+  <elements-api apiDescriptionUrl="/openapi.yml" router="hash" layout="sidebar" />
+</body>
+
+</html>

--- a/{{cookiecutter.app_name}}/lib/api/docs/views/openapi/show.html
+++ b/{{cookiecutter.app_name}}/lib/api/docs/views/openapi/show.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>Open API documentation</title>
+  <title>API documentation</title>
   <!-- Embed elements Elements via Web Component -->
   <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">

--- a/{{cookiecutter.app_name}}/lib/api/v1/routers/router.go
+++ b/{{cookiecutter.app_name}}/lib/api/v1/routers/router.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func ComebineRoutes(engine *gin.Engine) {
+func CombineRoutes(engine *gin.Engine) {
 	v1 := engine.Group("/api/v1")
 
 	v1.GET("/health", controllers.HealthController{}.HealthStatus)

--- a/{{cookiecutter.app_name}}/lib/web/routers/router.go
+++ b/{{cookiecutter.app_name}}/lib/web/routers/router.go
@@ -10,7 +10,7 @@ import (
 	eztemplate "github.com/michelloworld/ez-gin-template"
 )
 
-func ComebineRoutes(engine *gin.Engine) {
+func CombineRoutes(engine *gin.Engine) {
 	// Register HTML renderer
 	htmlRender := eztemplate.New()
 	htmlRender.Debug = gin.IsDebugging()


### PR DESCRIPTION
#105

## What happened 👀

- Added an endpoint (`/api/docs/openapi`) to support generating OpenAPI docs by using https://github.com/stoplightio/elements

## Insight 📝

This is `Part 2` for the #105 issue. I configured https://github.com/stoplightio/elements to visualize the OpenAPI into the gin templates. Here is the checklist of #105 when this pull request is merged:

- [x] Add OpenAPI addon as an optional addon in the template.
- [x] Add OpenAPI tooling (Spectral, Elements, Lint).
- [x] Create an endpoint (e.g., GET {{base_url}}/api/docs/openapi) to access the API documentation through the browser.
- [ ] Add Mock Server with Prims (related to this [API Mock Server with OpenAPI](https://www.notion.so/API-Mock-Server-with-OpenAPI-83fda1653eb1409fab9b08c1fcf466fd?pvs=21)).
- [ ] Add CI/CD workflow to run linting and deploy mock server to fly.io:
  - [x] Linting
  -	[ ] Deploy Mock Server

## Proof Of Work 📹

![Screenshot 2023-08-14 at 15 15 17](https://github.com/nimblehq/gin-templates/assets/19943832/4aefed6f-15e5-44de-ab64-a93416fa2dd3)

