### PR TITLE
[#105] [Part3] Add OpenAPI to support creating API documentation with OpenAPI

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1142,4 +1142,74 @@ var _ = Describe("Create template", func() {
 			Expect(content).To(ContainSubstring(expectedContent))
 		})
 	})
+
+	Context("given mock_server add-on", func() {
+		It("contains deploy_mock_server.yml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:       "test-gin-templates",
+				UseMockServer: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".github/workflows/deploy_mock_server.yml")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains Dockerfile.mock file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:       "test-gin-templates",
+				UseMockServer: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("Dockerfile.mock")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+
+		It("contains fly.toml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:       "test-gin-templates",
+				UseMockServer: tests.Yes,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("fly.toml")
+
+			Expect(os.IsNotExist(err)).To(BeFalse())
+		})
+	})
+
+	Context("given NO mock_server add-on", func() {
+		It("does NOT contains deploy_mock_server.yml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:       "test-gin-templates",
+				UseMockServer: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat(".github/workflows/deploy_mock_server.yml")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contains Dockerfile.mock file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:       "test-gin-templates",
+				UseMockServer: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("Dockerfile.mock")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+
+		It("does NOT contains fly.toml file", func() {
+			cookiecutter := tests.Cookiecutter{
+				AppName:       "test-gin-templates",
+				UseMockServer: tests.No,
+			}
+			cookiecutter.CreateProjectFromGinTemplate(currentTemplatePath)
+			_, err := os.Stat("fly.toml")
+
+			Expect(os.IsNotExist(err)).To(BeTrue())
+		})
+	})
 })

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "css_addon": ["Bootstrap", "Tailwind", "None"],
   "use_logrus": ["yes", "no"],
   "use_heroku": ["yes", "no"],
-  "use_mock_server": ["yes","no"],
+  "use_mock_server": ["yes", "no"],
 
   "_api_variant": "no",
   "_web_variant": "no",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
   "css_addon": ["Bootstrap", "Tailwind", "None"],
   "use_logrus": ["yes", "no"],
   "use_heroku": ["yes", "no"],
+  "use_mock_server": ["yes","no"],
 
   "_api_variant": "no",
   "_web_variant": "no",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -109,6 +109,15 @@ if '{{ cookiecutter._api_variant }}' == 'no':
     remove_file(".spectral.yaml")
     remove_file(".github/workflows/lint_docs.yml")
 
+# Remove mock_server if not seleted
+if '{{ cookiecutter.use_mock_server }}' == 'no':
+    print_log('Removing mock_server')
+
+    # mock_server related files
+    remove_file("Dockerfile.mock")
+    remove_file("fly.toml")
+    remove_file(".github/workflows/deploy_mock_server.yml")
+
 # Download the missing dependencies
 print_log('Downloading dependencies')
 subprocess.call(['go', 'mod', 'tidy'])

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -28,4 +28,13 @@ Only project with web:
         {{ cookiecutter.update({ '_tailwind_addon': 'yes' }) }}
     {% endif %}
 {% endif %}
+
+-----------
+Mock Server
+cookiecutter.use_mock_server
+-----------
+Only project with openapi:
+{% if cookiecutter._api_variant == 'no' %}
+    {{ cookiecutter.update({ 'use_mock_server': 'no' }) }}
+{% endif %}
 '''

--- a/tests/cookiecutter.go
+++ b/tests/cookiecutter.go
@@ -25,11 +25,12 @@ const (
 
 // Field and order MUST be the same as cookiecutter.json
 type Cookiecutter struct {
-	AppName   string
-	Variant   Variants
-	CssAddon  CssAddons
-	UseLogrus Choices
-	UseHeroku Choices
+	AppName       string
+	Variant       Variants
+	CssAddon      CssAddons
+	UseLogrus     Choices
+	UseHeroku     Choices
+	UseMockServer Choices
 }
 
 func (c *Cookiecutter) fillDefaultValue() {
@@ -43,6 +44,10 @@ func (c *Cookiecutter) fillDefaultValue() {
 
 	if c.UseHeroku != Yes && c.UseHeroku != No {
 		c.UseHeroku = No
+	}
+
+	if c.UseMockServer != Yes && c.UseMockServer != No {
+		c.UseMockServer = No
 	}
 
 	if c.CssAddon != Bootstrap && c.CssAddon != Tailwind && c.CssAddon != None {

--- a/{{cookiecutter.app_name}}/.github/workflows/deploy_mock_server
+++ b/{{cookiecutter.app_name}}/.github/workflows/deploy_mock_server
@@ -1,0 +1,22 @@
+name: Deploy Mock Server
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  deploy:
+    name: Deploy server mock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to fly
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/{{cookiecutter.app_name}}/.github/workflows/deploy_mock_server.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/deploy_mock_server.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Deploy to fly
         run: flyctl deploy --remote-only
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: {{ "${{ secrets.FLY_API_TOKEN }}" }}

--- a/{{cookiecutter.app_name}}/.github/workflows/deploy_mock_server.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/deploy_mock_server.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy server mock
+    name: Deploy mock server
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/{{cookiecutter.app_name}}/Dockerfile.mock
+++ b/{{cookiecutter.app_name}}/Dockerfile.mock
@@ -1,0 +1,7 @@
+FROM stoplight/prism:latest
+
+COPY /docs /usr/src/prism/packages/cli/docs/
+
+EXPOSE 80
+
+CMD ["mock", "-h", "0.0.0.0", "-p", "80", "docs/openapi/openapi.yml"]

--- a/{{cookiecutter.app_name}}/fly.toml
+++ b/{{cookiecutter.app_name}}/fly.toml
@@ -1,0 +1,13 @@
+app = "api-mock-server"
+primary_region = "sin"
+
+[build]
+  dockerfile = "Dockerfile.mock"
+
+[http_service]
+  internal_port = 80
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]


### PR DESCRIPTION
Resolve #105 

## What happened 👀

- Added `Dockerfile.mock`
- Added `fly.toml`
- Added `deploy_mock_server.yml`

## Insight 📝

Support `mock_server` add-on for the templates. This will help developers to deploy a mock server based on OpenAPI spec.

Here is the checklist of #105 when this pull request is merged:

- [x] Add OpenAPI addon as an optional addon in the template.
- [x] Add OpenAPI tooling (Spectral, Elements, Lint).
- [x] Create an endpoint (e.g., GET {{base_url}}/api/docs/openapi) to access the API documentation through the browser.
- [x] Add Mock Server with Prims (related to this [API Mock Server with OpenAPI](https://www.notion.so/API-Mock-Server-with-OpenAPI-83fda1653eb1409fab9b08c1fcf466fd?pvs=21)).
- [x] Add CI/CD workflow to run linting and deploy mock server to fly.io:
  - [x] Linting
  -	[x] Deploy Mock Server

## Proof Of Work 📹

- CI passed
- The work based on https://github.com/nimblehq/api-mock-templates and [API Mock Server with Prism](https://www.notion.so/nimblehq/API-Mock-Server-with-Prism-396c1c62064c460586958535846f0dc2?pvs=4)
